### PR TITLE
OTC-811: Validation of insuree number fix

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -7,7 +7,7 @@ import {
   decodeId,
   formatMutation,
   formatGQLString,
-  graphqlWithVariables
+  graphqlWithVariables,
 } from "@openimis/fe-core";
 
 const FAMILY_HEAD_PROJECTION = "headInsuree{id,uuid,chfId,lastName,otherNames,email,phone,dob,gender{code}}";
@@ -407,9 +407,13 @@ export function changeFamily(mm, family_uuid, insuree, cancelPolicies, clientMut
 export function insureeNumberValidationCheck(mm, variables) {
   return graphqlWithVariables(
     `
-      query ($number: String!) {
-        isValid: insureeNumberValidity(insureeNumber: $number)
+    query ($insuranceNumber: String!) {
+      insureeNumberValidity(insureeNumber: $insuranceNumber) {
+        isValid
+        errorCode
+        errorMessage
       }
+    }
     `,
     variables,
     `INSUREE_NUMBER_VALIDATION_FIELDS`,

--- a/src/actions.js
+++ b/src/actions.js
@@ -416,6 +416,12 @@ export function insureeNumberValidationCheck(mm, variables) {
   );
 }
 
+export function insureeNumberSetValid() {
+  return (dispatch) => {
+    dispatch({ type: `INSUREE_NUMBER_VALIDATION_FIELDS_SET_VALID` });
+  };
+}
+
 export function insureeNumberValidationClear() {
   return (dispatch) => {
     dispatch({ type: `INSUREE_NUMBER_VALIDATION_FIELDS_CLEAR` });

--- a/src/components/InsureeForm.js
+++ b/src/components/InsureeForm.js
@@ -97,6 +97,7 @@ class InsureeForm extends Component {
   };
 
   canSave = () => {
+    if (!this.props.isInsureeNumberValid) return false;
     if (!this.state.insuree.chfId) return false;
     if (!this.state.insuree.lastName) return false;
     if (!this.state.insuree.otherNames) return false;
@@ -191,6 +192,7 @@ const mapStateToProps = (state, props) => ({
   family: state.insuree.family,
   submittingMutation: state.insuree.submittingMutation,
   mutation: state.insuree.mutation,
+  isInsureeNumberValid: state.insuree?.validationFields?.insureeNumber?.isValid,
 });
 
 export default withHistory(

--- a/src/pickers/InsureeNumberInput.js
+++ b/src/pickers/InsureeNumberInput.js
@@ -1,19 +1,25 @@
 import React from "react";
-import {
-  withModulesManager,
-  useModulesManager,
-  ValidatedTextInput,
-} from "@openimis/fe-core";
 import { connect } from "react-redux";
 import { injectIntl } from "react-intl";
-import {insureeNumberValidationCheck, insureeNumberValidationClear} from "../actions";
 
+import { withModulesManager, useModulesManager, ValidatedTextInput } from "@openimis/fe-core";
+import { insureeNumberValidationCheck, insureeNumberValidationClear, insureeNumberSetValid } from "../actions";
 
 const InsureeNumberInput = (props) => {
-  const { value, onChange, className, label = "Insuree.chfId", placeholder, readOnly, required,
-          isInsureeNumberValid, isInsureeNumberValidating, insureeNumberValidationError } = props;
+  const {
+    value,
+    onChange,
+    className,
+    label,
+    placeholder,
+    readOnly,
+    required,
+    isInsureeNumberValid,
+    isInsureeNumberValidating,
+    insureeNumberValidationError,
+  } = props;
   const modulesManager = useModulesManager();
-  const numberMaxLength = modulesManager.getConf("fe-insuree", "insureeForm.chfIdMaxLength", 12)
+  const numberMaxLength = modulesManager.getConf("fe-insuree", "insureeForm.chfIdMaxLength", 12);
 
   const shouldValidate = (inputValue) => {
     const { savedInsureeNumber } = props;
@@ -30,6 +36,7 @@ const InsureeNumberInput = (props) => {
       validationError={insureeNumberValidationError}
       action={insureeNumberValidationCheck}
       clearAction={insureeNumberValidationClear}
+      setValidAction={insureeNumberSetValid}
       module="insuree"
       className={className}
       disabled={readOnly}
@@ -37,18 +44,17 @@ const InsureeNumberInput = (props) => {
       label={label}
       placeholder={placeholder}
       value={value}
-      inputProps={{ maxLength: numberMaxLength}}
+      inputProps={{ maxLength: numberMaxLength }}
       onChange={onChange}
     />
   );
 };
 
 const mapStateToProps = (state) => ({
-    isInsureeNumberValid: state.insuree.validationFields?.insureeNumber?.isValid,
-    isInsureeNumberValidating: state.insuree.validationFields?.insureeNumber?.isValidating,
-    insureeNumberValidationError: state.insuree.validationFields?.insureeNumber?.validationError,
-    savedInsureeNumber: state.insuree?.insuree?.chfId,
-  });
-
+  isInsureeNumberValid: state.insuree.validationFields?.insureeNumber?.isValid,
+  isInsureeNumberValidating: state.insuree.validationFields?.insureeNumber?.isValidating,
+  insureeNumberValidationError: state.insuree.validationFields?.insureeNumber?.validationError,
+  savedInsureeNumber: state.insuree?.insuree?.chfId,
+});
 
 export default withModulesManager(connect(mapStateToProps)(injectIntl(InsureeNumberInput)));

--- a/src/pickers/InsureeNumberInput.js
+++ b/src/pickers/InsureeNumberInput.js
@@ -17,6 +17,7 @@ const InsureeNumberInput = (props) => {
     isInsureeNumberValid,
     isInsureeNumberValidating,
     insureeNumberValidationError,
+    insureeNumberValidationErrorMessage,
   } = props;
   const modulesManager = useModulesManager();
   const numberMaxLength = modulesManager.getConf("fe-insuree", "insureeForm.chfIdMaxLength", 12);
@@ -28,8 +29,8 @@ const InsureeNumberInput = (props) => {
 
   return (
     <ValidatedTextInput
-      itemQueryIdentifier="number"
-      codeTakenLabel={"InsureeNumberInput.error"}
+      itemQueryIdentifier="insuranceNumber"
+      codeTakenLabel={insureeNumberValidationErrorMessage}
       shouldValidate={shouldValidate}
       isValid={isInsureeNumberValid}
       isValidating={isInsureeNumberValidating}
@@ -54,6 +55,7 @@ const mapStateToProps = (state) => ({
   isInsureeNumberValid: state.insuree.validationFields?.insureeNumber?.isValid,
   isInsureeNumberValidating: state.insuree.validationFields?.insureeNumber?.isValidating,
   insureeNumberValidationError: state.insuree.validationFields?.insureeNumber?.validationError,
+  insureeNumberValidationErrorMessage: state.insuree.validationFields?.insureeNumber?.validationErrorMessage,
   savedInsureeNumber: state.insuree?.insuree?.chfId,
 });
 

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -424,6 +424,7 @@ function reducer(
           insureeNumber: {
             isValidating: true,
             isValid: false,
+            validationErrorMessage: null,
             validationError: null,
           },
         },
@@ -435,7 +436,8 @@ function reducer(
           ...state.validationFields,
           insureeNumber: {
             isValidating: false,
-            isValid: action.payload?.data.isValid,
+            isValid: action.payload?.data.insureeNumberValidity.isValid,
+            validationErrorMessage: action.payload?.data.insureeNumberValidity.errorMessage,
             validationError: formatGraphQLError(action.payload),
           },
         },
@@ -460,6 +462,7 @@ function reducer(
           insureeNumber: {
             isValidating: true,
             isValid: false,
+            validationErrorMessage: null,
             validationError: null,
           },
         },
@@ -472,6 +475,7 @@ function reducer(
           insureeNumber: {
             isValidating: false,
             isValid: true,
+            validationErrorMessage: null,
             validationError: null,
           },
         },

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -464,6 +464,18 @@ function reducer(
           },
         },
       };
+    case "INSUREE_NUMBER_VALIDATION_FIELDS_SET_VALID":
+      return {
+        ...state,
+        validationFields: {
+          ...state.validationFields,
+          insureeNumber: {
+            isValidating: false,
+            isValid: true,
+            validationError: null,
+          },
+        },
+      };
     case "INSUREE_MUTATION_REQ":
       return dispatchMutationReq(state, action);
     case "INSUREE_MUTATION_ERR":

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -222,7 +222,6 @@
   "insuree.selectHeadInsuree.tooltip": "Select existing insuree as head",
   "insuree.addInsuree.alert.title": "Add insuree to family warning(s):",
   "insuree.addInsuree.alert.message": "However, insuree can still be added to the family.",
-  "insuree.InsureeNumberInput.error": "Insurance number already in use",
   "insuree.EnrolledFamiliesReport.dateFrom": "From Date",
   "insuree.EnrolledFamiliesReport.dateTo": "To Date",
   "insuree.InsureeFamilyOverviewReport.dateFrom": "From Date",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -222,7 +222,7 @@
   "insuree.selectHeadInsuree.tooltip": "Select existing insuree as head",
   "insuree.addInsuree.alert.title": "Add insuree to family warning(s):",
   "insuree.addInsuree.alert.message": "However, insuree can still be added to the family.",
-  "insuree.InsureeNumberInput.error": "Invalid Insuree Number",
+  "insuree.InsureeNumberInput.error": "Insurance number already in use",
   "insuree.EnrolledFamiliesReport.dateFrom": "From Date",
   "insuree.EnrolledFamiliesReport.dateTo": "To Date",
   "insuree.InsureeFamilyOverviewReport.dateFrom": "From Date",


### PR DESCRIPTION
[OTC-811](https://openimis.atlassian.net/browse/OTC-811)

In scope of this ticket, I corrected the validation of the insuree number. Now, when it is invalid, there is no possibility to save the form (save button is disabled).
Moreover, the warning message has been changed from "_Invalid Insuree Number_" to "_Insurance number already in use_".

Related BE: [CORE PR](https://github.com/openimis/openimis-be-core_py/pull/148) and [INSUREE PR](https://github.com/openimis/openimis-be-insuree_py/pull/47)

[OTC-811]: https://openimis.atlassian.net/browse/OTC-811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ