### PR TITLE
OP-1084: FamilySearcher, InsureeSearcher, InsureePicker pagination fix

### DIFF
--- a/src/components/FamilySearcher.js
+++ b/src/components/FamilySearcher.js
@@ -56,12 +56,16 @@ class FamilySearcher extends Component {
     let prms = Object.keys(state.filters)
       .filter((family) => !!state.filters[family]["filter"])
       .map((family) => state.filters[family]["filter"]);
-    prms.push(`first: ${state.pageSize}`);
+    if (!state.beforeCursor && !state.afterCursor) {
+      prms.push(`first: ${state.pageSize}`);
+    }
     if (!!state.afterCursor) {
       prms.push(`after: "${state.afterCursor}"`);
+      prms.push(`first: ${state.pageSize}`);
     }
     if (!!state.beforeCursor) {
       prms.push(`before: "${state.beforeCursor}"`);
+      prms.push(`last: ${state.pageSize}`);
     }
     if (!!state.orderBy) {
       prms.push(`orderBy: ["${state.orderBy}"]`);

--- a/src/components/InsureeSearcher.js
+++ b/src/components/InsureeSearcher.js
@@ -63,12 +63,16 @@ class InsureeSearcher extends Component {
     let prms = Object.keys(state.filters)
       .filter((f) => !!state.filters[f]["filter"])
       .map((f) => state.filters[f]["filter"]);
-    prms.push(`first: ${state.pageSize}`);
+    if (!state.beforeCursor && !state.afterCursor) {
+      prms.push(`first: ${state.pageSize}`);
+    }
     if (!!state.afterCursor) {
       prms.push(`after: "${state.afterCursor}"`);
+      prms.push(`first: ${state.pageSize}`);
     }
     if (!!state.beforeCursor) {
       prms.push(`before: "${state.beforeCursor}"`);
+      prms.push(`last: ${state.pageSize}`);
     }
     if (!!state.orderBy) {
       prms.push(`orderBy: ["${state.orderBy}"]`);

--- a/src/pickers/InsureePicker.js
+++ b/src/pickers/InsureePicker.js
@@ -111,12 +111,16 @@ class InsureePicker extends Component {
 
   filtersToQueryParams = () => {
     let prms = [...(this.props.forcedFilter || []), ...this.state.filters];
-    prms = prms.concat(`first: ${this.state.pageSize}`);
+    if (!this.state.beforeCursor && !this.state.afterCursor) {
+      prms.push(`first: ${this.state.pageSize}`);
+    }
     if (!!this.state.afterCursor) {
-      prms = prms.concat(`after: "${this.state.afterCursor}"`);
+      prms.push(`after: "${this.state.afterCursor}"`);
+      prms.push(`first: ${this.state.pageSize}`);
     }
     if (!!this.state.beforeCursor) {
-      prms = prms.concat(`before: "${this.state.beforeCursor}"`);
+      prms.push(`before: "${this.state.beforeCursor}"`);
+      prms.push(`last: ${this.state.pageSize}`);
     }
     return prms;
   };


### PR DESCRIPTION
[OP-1084](https://openimis.atlassian.net/browse/OP-1084)

Changes:
- Pagination fix in _**FamilySearcher.js**_, _**InsureeSearcher.js**_ and **_InsureePicker.js_**. **Last** and **first** parameters had to be adjusted to the existing logic.

[OP-1084]: https://openimis.atlassian.net/browse/OP-1084?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ