### PR TITLE
OTC-989: Selecting existing insuree as a head fix

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -98,6 +98,12 @@ export function fetchInsureesForPicker(mm, filters) {
   return graphql(payload, "INSUREE_INSUREES");
 }
 
+export function clearInsuree() {
+  return (dispatch) => {
+    dispatch({type: "INSUREE_INSUREE_CLEAR"})
+  }
+}
+
 export function fetchFamilySummaries(mm, filters) {
   let projections = [
     "id",

--- a/src/components/FamilyForm.js
+++ b/src/components/FamilyForm.js
@@ -125,6 +125,7 @@ class FamilyForm extends Component {
     if (!this.state.family.location) return false;
     if (!this.state.family.headInsuree) return false;
     if (!this.state.family.headInsuree.chfId) return false;
+    if (!this.props.isChfIdValid) return false;
     if (!this.state.family.headInsuree.lastName) return false;
     if (!this.state.family.headInsuree.otherNames) return false;
     if (!this.state.family.headInsuree.dob) return false;
@@ -240,6 +241,7 @@ const mapStateToProps = (state, props) => ({
   insuree: state.insuree.insuree,
   confirmed: state.core.confirmed,
   state: state,
+  isChfIdValid: state.insuree?.validationFields?.insureeNumber?.isValid,
 });
 
 const mapDispatchToProps = (dispatch) => {

--- a/src/components/HeadInsureeMasterPanel.js
+++ b/src/components/HeadInsureeMasterPanel.js
@@ -2,20 +2,31 @@ import React, { Component, Fragment } from "react";
 import InsureeMasterPanel from "./InsureeMasterPanel";
 import { injectIntl } from "react-intl";
 import { connect } from "react-redux";
-import { Contributions, PublishedComponent, formatMessage, withModulesManager,} from "@openimis/fe-core";
+import { Contributions, PublishedComponent, formatMessage, withModulesManager } from "@openimis/fe-core";
 import { PersonAdd as AddExistingIcon } from "@material-ui/icons";
-import {fetchInsureeFull} from "../actions";
+import { fetchInsureeFull } from "../actions";
 
 const INSUREE_HEAD_INSUREE_PANELS_CONTRIBUTION_KEY = "insuree.HeadInsuree.panels";
 
 class HeadInsureeMasterPanel extends Component {
+  state = {
+    headSelected: false,
+  };
+
   onEditedChanged = (head) => {
     let edited = { ...this.props.edited };
     edited["headInsuree"] = head;
     this.props.onEditedChanged(edited);
     if (head && head.uuid) {
-      this.props.dispatch(fetchInsureeFull(this.props.modulesManager, head.uuid))
+      this.props.dispatch(fetchInsureeFull(this.props.modulesManager, head.uuid));
     }
+  };
+
+  checkIfHeadSelected = (insuree) => {
+    Boolean(insuree) &&
+      this.setState({
+        headSelected: true,
+      });
   };
 
   render() {
@@ -27,6 +38,7 @@ class HeadInsureeMasterPanel extends Component {
             <PublishedComponent //div needed for the tooltip style!!
               pubRef="insuree.InsureePicker"
               IconRender={AddExistingIcon}
+              checkIfHeadSelected={this.checkIfHeadSelected}
               forcedFilter={["head: false"]}
               onChange={this.onEditedChanged}
             />
@@ -43,6 +55,7 @@ class HeadInsureeMasterPanel extends Component {
           onEditedChanged={this.onEditedChanged}
           title="insuree.HeadInsureeMasterPanel.title"
           actions={actions}
+          headSelected={this.state.headSelected}
         />
         <Contributions
           {...this.props}

--- a/src/components/InsureeForm.js
+++ b/src/components/InsureeForm.js
@@ -17,7 +17,7 @@ import { RIGHT_INSUREE } from "../constants";
 import FamilyDisplayPanel from "./FamilyDisplayPanel";
 import InsureeMasterPanel from "../components/InsureeMasterPanel";
 
-import { fetchInsureeFull, fetchFamily } from "../actions";
+import { fetchInsureeFull, fetchFamily, clearInsuree } from "../actions";
 import { insureeLabel } from "../utils/utils";
 
 const styles = (theme) => ({
@@ -76,6 +76,10 @@ class InsureeForm extends Component {
       this.setState({ reset: this.state.reset + 1 });
     }
   }
+
+  componentWillUnmount = () => {
+    this.props.clearInsuree();
+  };
 
   _add = () => {
     this.setState(
@@ -198,7 +202,7 @@ const mapStateToProps = (state, props) => ({
 
 export default withHistory(
   withModulesManager(
-    connect(mapStateToProps, { fetchInsureeFull, fetchFamily, journalize })(
+    connect(mapStateToProps, { fetchInsureeFull, fetchFamily, clearInsuree, journalize })(
       injectIntl(withTheme(withStyles(styles)(InsureeForm))),
     ),
   ),

--- a/src/components/InsureeMasterPanel.js
+++ b/src/components/InsureeMasterPanel.js
@@ -35,6 +35,7 @@ class InsureeMasterPanel extends FormPanel {
       readOnly = true,
       actions,
       edited_id,
+      headSelected,
     } = this.props;
     return (
       <Grid container>
@@ -83,6 +84,7 @@ class InsureeMasterPanel extends FormPanel {
                   label="Insuree.chfId"
                   required={true}
                   readOnly={readOnly}
+                  headSelected={headSelected}
                   value={edited?.chfId}
                   edited_id={edited_id}
                   onChange={(v) => this.updateAttribute("chfId", v)}

--- a/src/pages/FamilyPage.js
+++ b/src/pages/FamilyPage.js
@@ -5,7 +5,7 @@ import { bindActionCreators } from "redux";
 import { withTheme, withStyles } from "@material-ui/core/styles";
 import { formatMessageWithValues, withModulesManager, withHistory, historyPush } from "@openimis/fe-core";
 import FamilyForm from "../components/FamilyForm";
-import { createFamily, updateFamily } from "../actions";
+import { createFamily, updateFamily, clearInsuree } from "../actions";
 import { RIGHT_FAMILY, RIGHT_FAMILY_ADD, RIGHT_FAMILY_EDIT } from "../constants";
 import { familyLabel } from "../utils/utils";
 
@@ -38,6 +38,10 @@ class FamilyPage extends Component {
     }
   };
 
+  componentWillUnmount = () => {
+    this.props.clearInsuree();
+  };
+
   render() {
     const { classes, modulesManager, history, rights, family_uuid, overview } = this.props;
     if (!rights.includes(RIGHT_FAMILY)) return null;
@@ -63,7 +67,7 @@ const mapStateToProps = (state, props) => ({
 });
 
 const mapDispatchToProps = (dispatch) => {
-  return bindActionCreators({ createFamily, updateFamily }, dispatch);
+  return bindActionCreators({ createFamily, updateFamily, clearInsuree }, dispatch);
 };
 
 export default withHistory(

--- a/src/pickers/InsureeNumberInput.js
+++ b/src/pickers/InsureeNumberInput.js
@@ -23,9 +23,11 @@ const InsureeNumberInput = (props) => {
   const numberMaxLength = modulesManager.getConf("fe-insuree", "insureeForm.chfIdMaxLength", 12);
 
   const shouldValidate = (inputValue) => {
-    const { savedInsureeNumber, edited_id } = props;
-    if (edited_id) return inputValue !== savedInsureeNumber;
-    else return true;
+    const { savedInsureeNumber, headSelected } = props;
+
+    if (headSelected && savedInsureeNumber && inputValue === savedInsureeNumber) return false;
+
+    if (!headSelected || (headSelected && savedInsureeNumber)) return inputValue !== savedInsureeNumber;
   };
 
   return (

--- a/src/pickers/InsureePicker.js
+++ b/src/pickers/InsureePicker.js
@@ -149,6 +149,7 @@ class InsureePicker extends Component {
   };
 
   onSelect = (v) => {
+    this.props.checkIfHeadSelected(v);
     this.setState({ selected: v }, this.props.onChange(v, this.formatSuggestion(v)));
   };
 

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -87,6 +87,14 @@ function reducer(
         fetchingInsuree: false,
         errorInsuree: formatServerError(action.payload),
       };
+    case "INSUREE_INSUREE_CLEAR":
+      return {
+        ...state,
+        fetchingInsuree: true,
+        fetchedInsuree: false,
+        insuree: null,
+        errorInsuree: null,
+      };
     case "INSUREE_FAMILY_NEW":
       return {
         ...state,


### PR DESCRIPTION
[OTC-989](https://openimis.atlassian.net/browse/OTC-989)

Changes:
- Implementation of additional state which clarifies when user is selecting existing insuree as a head.
- Implementation of _clearInsuree_ action and using it where it is neccessary.

Now, user can select an existing insuree as a head and if all required fields are filled, the form allows to save. Moreover, if there will be a change of insuree number, it is still validated and there is no way to save a form with duplicated code.

[OTC-989]: https://openimis.atlassian.net/browse/OTC-989?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ