### PR TITLE
OTC-1012: Editing after save blocked, restoring reload functionality

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -162,6 +162,15 @@ export function fetchFamilyMutation(mm, clientMutationId) {
   return graphql(payload, "INSUREE_INSUREE");
 }
 
+export function fetchInsureeMutation(mm, clientMutationId) {
+  let payload = formatPageQuery(
+    "mutationLogs",
+    [`clientMutationId:"${clientMutationId}"`],
+    ["id", "insurees{insuree{uuid}}"],
+  );
+  return graphql(payload, "INSUREE_INSUREE");
+}
+
 export function fetchInsureeOfficers(mm) {
   const payload = formatPageQuery("insureeOfficers", null, mm.getRef("insuree.InsureeOfficerPicker.projection"));
   return graphql(payload, "INSUREE_INSUREE_OFFICERS");

--- a/src/components/FamilyForm.js
+++ b/src/components/FamilyForm.js
@@ -93,7 +93,6 @@ class FamilyForm extends Component {
 
   reload = () => {
     const { family } = this.state;
-    console.log(this.props);
     const { clientMutationId, familyUuid } = this.props.mutation;
     if (clientMutationId && !familyUuid) {
       // creation, we need to fetch the new family uuid from mutations logs and redirect to family overview

--- a/src/components/FamilyForm.js
+++ b/src/components/FamilyForm.js
@@ -93,6 +93,7 @@ class FamilyForm extends Component {
 
   reload = () => {
     const { family } = this.state;
+    console.log(this.props);
     const { clientMutationId, familyUuid } = this.props.mutation;
     if (clientMutationId && !familyUuid) {
       // creation, we need to fetch the new family uuid from mutations logs and redirect to family overview


### PR DESCRIPTION
[OTC-1012](https://openimis.atlassian.net/browse/OTC-1012)

Changes:
1. Fetching insuree mutation to enable redirect to specified paths after reload and to adjust styles/_readOnly_ property.
2. There are 4 scenarios which were considered here:
- reloading after save when an insuree was **created** or **edited** (from the **family overview panel**) --> redirect to **this family** overview panel
- reloading after save when an insuree was **edited** (from the **insurees tab**) --> redirect to **this insuree** and enable editing
- reloading after save when an insuree was **created** (from the **insurees tab**) --> redirect to **this** newly created **insuree** and enable editing

At the moment, if you create an insuree from the insurees tab, the family is not attached to it and it is not possible to take some action on it. I created another ticket for it. Since this issue is not fixed, redirecting to the newly created insuree won't work as intended.

[OTC-1012]: https://openimis.atlassian.net/browse/OTC-1012?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ