### PR TITLE
OP-1414: Use insurees family if family is not fetched

### DIFF
--- a/src/reducer.js
+++ b/src/reducer.js
@@ -73,6 +73,7 @@ function reducer(
         fetchedInsuree: false,
         insuree: null,
         errorInsuree: null,
+        family: null,
       };
     case "INSUREE_INSUREE_RESP":
       return {
@@ -81,6 +82,7 @@ function reducer(
         fetchedInsuree: true,
         insuree: parseData(action.payload.data.insurees)[0],
         errorInsuree: formatGraphQLError(action.payload),
+        family: parseData(action.payload.data.insurees)[0]?.family,
       };
     case "INSUREE_INSUREE_ERR":
       return {
@@ -95,6 +97,7 @@ function reducer(
         fetchedInsuree: false,
         insuree: null,
         errorInsuree: null,
+        family: null,
       };
     case "INSUREE_FAMILY_NEW":
       return {


### PR DESCRIPTION
[OP-1414](https://openimis.atlassian.net/browse/OP-1414)

Changes:
- Family has been added to the insuree reducer. It allows user to see family details when overviewing an insuree.

[OP-1414]: https://openimis.atlassian.net/browse/OP-1414?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ