### PR TITLE
OTC-1108: Implementation of InsureeNameByChfIdPicker and its necessar…

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ It is dedicated to be deployed as a module of [openimis-fe_js](https://github.co
 
 - `insuree.InsureePicker`, ability to search and select an insuree (via searcher dialog)
 - `insuree.InsureeChfIdPicker`, ability to select an insuree, from his (exact) CHFID
+- `insuree.InsureeNameByChfIdPicker`, ability to select an insuree name, from his (exact) CHFID
 - `insuree.InsureeNumberInput`, input that validates the insuree's number with the server
 - `insuree.InsureeOfficerPicker`, picker (select drop down) for insuree (enrolment) officers
 - `insuree.InsureeGenderPicker`, picker (drop down) for available insuree genders (male, female, other)
@@ -64,6 +65,7 @@ It is dedicated to be deployed as a module of [openimis-fe_js](https://github.co
 - `INSUREE_ENQUIRY_{REQ|RESP|ERR}`: fetching insuree main information (Known usage: enquiry dialog)
 - `INSUREE_FAMILY_{REQ|RESP|ERR}`: fetching insuree family information (Known usage: `insuree.FamilySummary` component)
 - `INSUREE_INSUREES_{REQ|RESP|ERR}`: fetching insurees with filter (CHFID, Name and/or OtherName). Known usage: `insuree.InsureePicker`
+- `INSUREE_INSUREE_NAME_{REQ|RESP|ERR}`: fetching insuree name and last name (Known usage: `insuree.InsureeNameByChfIdPicker`)
 
 ## Other Modules Listened Redux Actions
 

--- a/src/actions.js
+++ b/src/actions.js
@@ -88,6 +88,20 @@ export function fetchInsuree(mm, chfid) {
   return graphql(payload, "INSUREE_INSUREE");
 }
 
+export function fetchInsureeNameByChfId(mm, insureeChfId) {
+  const variables = {
+    insureeChfId,
+  };
+
+  return graphqlWithVariables(
+    `query ($insureeChfId: String!) {
+      insureeName: insureeNameByChfid(chfId: $insureeChfId)
+    }`,
+    variables,
+    "INSUREE_INSUREE_NAME",
+  );
+}
+
 export function fetchInsureeFull(mm, uuid) {
   let payload = formatPageQuery("insurees", [`uuid:"${uuid}"`], INSUREE_FULL_PROJECTION(mm), "clientMutationId");
   return graphql(payload, "INSUREE_INSUREE");

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ import InsureeOfficerPicker from "./pickers/InsureeOfficerPicker";
 import FamilyPicker from "./pickers/FamilyPicker";
 import InsureePicker from "./pickers/InsureePicker";
 import InsureeChfIdPicker from "./pickers/InsureeChfIdPicker";
+import InsureeNameByChfIdPicker from "./pickers/InsureeNameByChfIdPicker";
 import InsureeGenderPicker from "./pickers/InsureeGenderPicker";
 import EducationPicker from "./pickers/EducationPicker";
 import ProfessionPicker from "./pickers/ProfessionPicker";
@@ -101,6 +102,7 @@ const DEFAULT_CONFIG = {
     { key: "insuree.InsureeOfficerPicker.projection", ref: ["id", "uuid", "code", "lastName", "otherNames"] },
     { key: "insuree.InsureePicker", ref: InsureePicker },
     { key: "insuree.InsureeChfIdPicker", ref: InsureeChfIdPicker },
+    { key: "insuree.InsureeNameByChfIdPicker", ref: InsureeNameByChfIdPicker },
     { key: "insuree.InsureePicker.projection", ref: INSUREE_PICKER_PROJECTION },
     { key: "insuree.InsureePicker.sort", ref: "insuree__last_name" },
     { key: "insuree.FamilyPicker", ref: FamilyPicker },

--- a/src/pickers/InsureeNameByChfIdPicker.js
+++ b/src/pickers/InsureeNameByChfIdPicker.js
@@ -1,0 +1,66 @@
+import React, { useState, useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import _debounce from "lodash/debounce";
+
+import { Grid } from "@material-ui/core";
+
+import { useModulesManager, TextInput, ProgressOrError, useTranslations } from "@openimis/fe-core";
+import { fetchInsureeNameByChfId } from "../actions";
+
+const InsureeNameByChfIdPicker = ({ readOnly = false, required = false, onChange }) => {
+  const dispatch = useDispatch();
+  const modulesManager = useModulesManager();
+  const { formatMessage } = useTranslations("insuree", modulesManager);
+  const chfIdMaxLength = modulesManager.getConf("fe-insuree", "insureeForm.chfIdMaxLength", 12);
+  const debounceTime = modulesManager.getConf("fe-insuree", "debounceTime", 800);
+  const notFoundMessage = formatMessage("notFound");
+  const { fetchingInsureeName, errorInsureeName, insureeName } = useSelector((store) => store.insuree);
+  const [search, setSearch] = useState();
+
+  const formatInsureeName = (name) => {
+    if (!search) return null;
+
+    return !!name ? name : notFoundMessage;
+  };
+
+  const fetch = (chfId) => {
+    setSearch(chfId);
+    dispatch(fetchInsureeNameByChfId(modulesManager, chfId));
+  };
+
+  const debouncedFetch = _debounce(fetch, debounceTime);
+
+  useEffect(() => {
+    const formattedName = formatInsureeName(insureeName);
+    if (insureeName) {
+      onChange(formattedName);
+    }
+  }, [insureeName]);
+
+  return (
+    <Grid container>
+      <Grid item xs={4}>
+        <TextInput
+          readOnly={readOnly}
+          autoFocus={true}
+          module="insuree"
+          label="Insuree.chfId"
+          value={search}
+          onChange={(v) => debouncedFetch(v)}
+          inputProps={{
+            "maxLength": chfIdMaxLength,
+          }}
+          required={required}
+        />
+      </Grid>
+      <Grid item xs={8}>
+        <ProgressOrError progress={fetchingInsureeName} error={errorInsureeName} />
+        {!fetchingInsureeName && (
+          <TextInput readOnly={true} module="insuree" label="Insuree.names" value={formatInsureeName(insureeName)} />
+        )}
+      </Grid>
+    </Grid>
+  );
+};
+
+export default InsureeNameByChfIdPicker;

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -90,6 +90,28 @@ function reducer(
         fetchingInsuree: false,
         errorInsuree: formatServerError(action.payload),
       };
+    case "INSUREE_INSUREE_NAME_REQ":
+      return {
+        ...state,
+        fetchingInsureeName: true,
+        fetchedInsureeName: false,
+        insureeName: null,
+        errorInsureeName: null,
+      };
+    case "INSUREE_INSUREE_NAME_RESP":
+      return {
+        ...state,
+        fetchingInsureeName: false,
+        fetchedInsureeName: true,
+        insureeName: action.payload.data?.insureeName,
+        errorInsureeName: formatGraphQLError(action.payload),
+      };
+    case "INSUREE_INSUREE_NAME_ERR":
+      return {
+        ...state,
+        fetchingInsureeName: false,
+        errorInsureeName: formatServerError(action.payload),
+      };
     case "INSUREE_INSUREE_CLEAR":
       return {
         ...state,


### PR DESCRIPTION
…y logic

**REQUIRED [CLAIM PR](https://github.com/openimis/openimis-fe-claim_js/pull/96)**
**REQUIRED [BE PR](https://github.com/openimis/openimis-be-claim_py/pull/105)**

[OTC-1108](https://openimis.atlassian.net/browse/OTC-1108)

I understand that the initial plan was to modify the query used by the _InsureeChfIdPicker_ component. However, after conducting research, I have determined that implementing a completely new picker solely responsible for fetching the insuree name would be a more reliable solution. This approach ensures that the existing functionality of the _InsureeChfIdPicker_ component, which is utilized by other components as well, remains unaffected.

Changes:
- Implementation of InsureeNameByChfIdPicker and action/reducers used by it.
- README updated.

[OTC-1108]: https://openimis.atlassian.net/browse/OTC-1108?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ