### PR TITLE
OP-1530: check if chfid valid only if family not defined

### DIFF
--- a/src/components/FamilyForm.js
+++ b/src/components/FamilyForm.js
@@ -125,7 +125,7 @@ class FamilyForm extends Component {
     if (!this.state.family.location) return false;
     if (!this.state.family.headInsuree) return false;
     if (!this.state.family.headInsuree.chfId) return false;
-    if (!this.props.isChfIdValid) return false;
+    if (!this.state.family.uuid && !this.props.isChfIdValid) return false;
     if (!this.state.family.headInsuree.lastName) return false;
     if (!this.state.family.headInsuree.otherNames) return false;
     if (!this.state.family.headInsuree.dob) return false;


### PR DESCRIPTION
[OP-1530](https://openimis.atlassian.net/browse/OP-1530)

Changes:
- Check if chfId of headInsuree is valid only in if family is not defined.

[OP-1530]: https://openimis.atlassian.net/browse/OP-1530?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ