### PR TITLE
OP-1434: block editing historical data, indication about historical data

### DIFF
--- a/src/components/FamilyForm.js
+++ b/src/components/FamilyForm.js
@@ -124,6 +124,7 @@ class FamilyForm extends Component {
   canSave = () => {
     if (!this.state.family.location) return false;
     if (!this.state.family.uuid && !this.props.isChfIdValid) return false;
+    if (this.state.family.validityTo) return false;
 
     return this.state.family.headInsuree && isValidInsuree(this.state.family.headInsuree, this.props.modulesManager);
   };

--- a/src/components/FamilyForm.js
+++ b/src/components/FamilyForm.js
@@ -177,8 +177,9 @@ class FamilyForm extends Component {
         onlyIfDirty: !readOnly && !runningMutation,
       });
     }
+    const shouldBeLocked = !!runningMutation || family?.validityTo;
     return (
-      <div className={!!runningMutation ? classes.lockedPage : null}>
+      <div className={shouldBeLocked ? classes.lockedPage : null}>
         <Helmet
           title={formatMessageWithValues(
             this.props.intl,

--- a/src/components/InsureeForm.js
+++ b/src/components/InsureeForm.js
@@ -192,8 +192,9 @@ class InsureeForm extends Component {
         onlyIfDirty: !readOnly && !runningMutation,
       },
     ];
+    const shouldBeLocked = !!runningMutation || insuree?.validityTo;
     return (
-      <div className={runningMutation ? classes.lockedPage : null}>
+      <div className={shouldBeLocked ? classes.lockedPage : null}>
         <Helmet
           title={formatMessageWithValues(this.props.intl, "insuree", "Insuree.title", {
             label: insureeLabel(this.state.insuree),

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -19,6 +19,7 @@ export const isValidInsuree = (insuree, modulesManager) => {
   );
 
   if (isInsureeFirstServicePointRequired && !insuree.healthFacility) return false;
+  if (family.validityTo) return false;
   if (!insuree.chfId) return false;
   if (!insuree.lastName) return false;
   if (!insuree.otherNames) return false;

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -19,7 +19,7 @@ export const isValidInsuree = (insuree, modulesManager) => {
   );
 
   if (isInsureeFirstServicePointRequired && !insuree.healthFacility) return false;
-  if (family.validityTo) return false;
+  if (insuree.validityTo) return false;
   if (!insuree.chfId) return false;
   if (!insuree.lastName) return false;
   if (!insuree.otherNames) return false;


### PR DESCRIPTION
[OP-1434](https://openimis.atlassian.net/browse/OP-1434)

Changes:
- Editing historical data is not allowed and saving such data is impossible.
- There is a specific background to indicate that a user is viewing historical data.

[OP-1434]: https://openimis.atlassian.net/browse/OP-1434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ