### PR TITLE
hotfix: restore insuree creation from family view

### DIFF
--- a/src/reducer.js
+++ b/src/reducer.js
@@ -73,7 +73,6 @@ function reducer(
         fetchedInsuree: false,
         insuree: null,
         errorInsuree: null,
-        family: null,
       };
     case "INSUREE_INSUREE_RESP":
       return {
@@ -82,7 +81,6 @@ function reducer(
         fetchedInsuree: true,
         insuree: parseData(action.payload.data.insurees)[0],
         errorInsuree: formatGraphQLError(action.payload),
-        family: parseData(action.payload.data.insurees)[0]?.family,
       };
     case "INSUREE_INSUREE_ERR":
       return {
@@ -97,7 +95,6 @@ function reducer(
         fetchedInsuree: false,
         insuree: null,
         errorInsuree: null,
-        family: null,
       };
     case "INSUREE_FAMILY_NEW":
       return {


### PR DESCRIPTION
Changes:
- Revert https://github.com/openimis/openimis-fe-insuree_js/pull/63. It was causing issues with creating an insuree from the family overview.