### PR TITLE
ONI-169: Insuree status set for new insurees.

### DIFF
--- a/src/components/InsureeMasterPanel.js
+++ b/src/components/InsureeMasterPanel.js
@@ -26,6 +26,14 @@ const INSUREE_INSUREE_CONTRIBUTION_KEY = "insuree.Insuree";
 const INSUREE_INSUREE_PANELS_CONTRIBUTION_KEY = "insuree.Insuree.panels";
 
 class InsureeMasterPanel extends FormPanel {
+  componentDidMount(prevProps, prevState, snapshot) {
+    this.isNewInsuree = false;
+    if(!this.props.edited?.status){
+      this.updateAttributes({ "status": INSUREE_ACTIVE_STRING, "statusReason": null });
+      this.isNewInsuree = true;
+    }
+  }
+
   render() {
     const {
       intl,
@@ -237,8 +245,9 @@ class InsureeMasterPanel extends FormPanel {
                       pubRef="insuree.InsureeStatusPicker"
                       label="Insuree.status"
                       value={edited?.status}
+                      withNull={false}
                       module="insuree"
-                      readOnly={readOnly}
+                      readOnly={this.isNewInsuree||this.props.readOnly}
                       onChange={(v) => this.updateAttributes({ "status": v, "statusReason": null })}
                       required={isInsureeStatusRequired}
                     />


### PR DESCRIPTION
Ticket: https://openimis.atlassian.net/browse/ONI-169

Changes:
- If insuree is added their status is set as active and cannot be changed
- Removed "any" option from dropdowns.