### PR TITLE
OM-79: add new navbar node on setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ It is dedicated to be deployed as a module of [openimis-fe_js](https://github.co
 - `insuree.InsureePage.panels`: `[InsureeMasterPanel, InsureeFirstServicePointPanel]`, contributing to own contribution point and register the defaults MasterPanel and First Service Point as panels of Insuree Page
 - `core.Router`: registering the `insuree/create`, `insuree/families`, `insuree/insurees`, `insuree/cappedItemService` and `insuree/profile` routes in openIMIS client-side router
 - `invoice.SubjectAndThirdpartyPicker`, providing Insuree picker and Family picker for Invoice module
+- `isWorker`: Specifies whether the individual should be classified and managed as a worker or a standard insuree. In Moldova, the Insuree entity is also used to represent workers. When set to true, the system displays 'Workers and Vouchers' instead of the default 'Insurees and Policies', aligning the interface with the specific needs of worker representation. Default: __false__.
 
 ## Available Contribution Points
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -16,6 +16,7 @@ export const RIGHT_FAMILY_ADD = 101002;
 export const RIGHT_FAMILY_EDIT = 101003;
 export const RIGHT_FAMILY_DELETE = 101004;
 export const RIGHT_INSUREE = 101101; //101100 in doc ... but in practice...
+export const RIGHT_WORKER = 101101;
 export const RIGHT_SEARCH = 101101;
 export const RIGHT_INSUREE_ADD = 101102;
 export const RIGHT_INSUREE_EDIT = 101103;

--- a/src/menus/InsureeMainMenu.js
+++ b/src/menus/InsureeMainMenu.js
@@ -3,14 +3,47 @@ import { injectIntl } from "react-intl";
 import { connect } from "react-redux";
 import { AssignmentInd, GroupAdd, People, Person } from "@material-ui/icons";
 import { formatMessage, MainMenuContribution, withModulesManager } from "@openimis/fe-core";
-import { RIGHT_FAMILY, RIGHT_FAMILY_ADD, RIGHT_INSUREE } from "../constants";
+import { DEFAULT, RIGHT_FAMILY, RIGHT_FAMILY_ADD, RIGHT_INSUREE, RIGHT_WORKER } from "../constants";
 
 const INSUREE_MAIN_MENU_CONTRIBUTION_KEY = "insuree.MainMenu";
+const WORKER_MAIN_MENU_CONTRIBUTION_KEY = "worker.MainMenu";
 
 class InsureeMainMenu extends Component {
+  constructor(props) {
+    super(props);
+    this.isWorker = props.modulesManager.getConf("fe-insuree", "isWorker", DEFAULT.IS_WORKER);
+  }
+
   render() {
     const { modulesManager, rights } = this.props;
     let entries = [];
+
+    if (this.isWorker) {
+      if (rights.includes(RIGHT_WORKER)) {
+        entries.push({
+          text: formatMessage(this.props.intl, "insuree", "menu.workers"),
+          icon: <People />,
+          route: `/${modulesManager.getRef("insuree.route.insurees")}`,
+        });
+      }
+      entries.push(
+        ...this.props.modulesManager
+          .getContribs(WORKER_MAIN_MENU_CONTRIBUTION_KEY)
+          .filter((c) => !c.filter || c.filter(rights)),
+      );
+
+      if (!entries) return null;
+
+      return (
+        <MainMenuContribution
+          {...this.props}
+          header={formatMessage(this.props.intl, "insuree", "workersMainMenu")}
+          icon={<AssignmentInd />}
+          entries={entries}
+        />
+      );
+    }
+
     if (rights.includes(RIGHT_FAMILY_ADD)) {
       entries.push({
         text: formatMessage(this.props.intl, "insuree", "menu.addFamilyOrGroup"),

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1,9 +1,11 @@
 {
   "insuree.appBar.enquiry": "Insuree enquiry…",
   "insuree.mainMenu": "Insurees and Policies",
+  "insuree.workersMainMenu": "Workers and Vouchers",
   "insuree.menu.addFamilyOrGroup": "Add Family/Group",
   "insuree.menu.familiesOrGroups": "Families/Groups",
   "insuree.menu.insurees": "Insurees",
+  "insuree.menu.workers": "Workers",
   "insuree.ageUnit": "Years",
   "insuree.label.regionFSP": "Region of FSP",
   "insuree.label.districtFSP": "District of FSP",


### PR DESCRIPTION
[OM-79](https://openimis.atlassian.net/browse/OM-79)

[REQUIRED PR](https://github.com/openimis/openimis-fe-worker_voucher_js/pull/1)

Changes:
- If user is using Moldova setup, instead of _Insurees and Policies_ display _Workers and Vouchers_.
![image](https://github.com/openimis/openimis-fe-insuree_js/assets/109145288/2f164984-86b8-4940-9841-567c1600c848)


[OM-79]: https://openimis.atlassian.net/browse/OM-79?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ