### PR TITLE
OP-1695: fix creating insuree from family panel

### DIFF
--- a/src/components/InsureeForm.js
+++ b/src/components/InsureeForm.js
@@ -18,8 +18,8 @@ import {
   Helmet,
 } from "@openimis/fe-core";
 import { fetchInsureeFull, fetchFamily, clearInsuree, fetchInsureeMutation } from "../actions";
-import {DEFAULT, RIGHT_INSUREE} from "../constants";
-import {insureeLabel, isValidInsuree, isValidWorker} from "../utils/utils";
+import { DEFAULT, INSUREE_ACTIVE_STRING, RIGHT_INSUREE } from "../constants";
+import { insureeLabel, isValidInsuree, isValidWorker } from "../utils/utils";
 import FamilyDisplayPanel from "./FamilyDisplayPanel";
 import InsureeMasterPanel from "../components/InsureeMasterPanel";
 import WorkerMasterPanel from "./worker/WorkerMasterPanel";
@@ -46,6 +46,8 @@ class InsureeForm extends Component {
   _newInsuree() {
     let insuree = {};
     insuree.jsonExt = {};
+    insuree.status = INSUREE_ACTIVE_STRING;
+    insuree.statusReason = null;
     return insuree;
   }
 
@@ -156,7 +158,9 @@ class InsureeForm extends Component {
     if (this.state.lockNew) return false;
     if (!this.props.isChfIdValid) return false;
 
-    return this.isWorker ? isValidWorker(this.state.insuree) : isValidInsuree(this.state.insuree, this.props.modulesManager);
+    return this.isWorker
+      ? isValidWorker(this.state.insuree)
+      : isValidInsuree(this.state.insuree, this.props.modulesManager);
   };
 
   _save = (insuree) => {

--- a/src/components/InsureeMasterPanel.js
+++ b/src/components/InsureeMasterPanel.js
@@ -26,14 +26,6 @@ const INSUREE_INSUREE_CONTRIBUTION_KEY = "insuree.Insuree";
 const INSUREE_INSUREE_PANELS_CONTRIBUTION_KEY = "insuree.Insuree.panels";
 
 class InsureeMasterPanel extends FormPanel {
-  componentDidMount(prevProps, prevState, snapshot) {
-    this.isNewInsuree = false;
-    if(!this.props.edited?.status){
-      this.updateAttributes({ "status": INSUREE_ACTIVE_STRING, "statusReason": null });
-      this.isNewInsuree = true;
-    }
-  }
-
   render() {
     const {
       intl,
@@ -247,7 +239,7 @@ class InsureeMasterPanel extends FormPanel {
                       value={edited?.status}
                       withNull={false}
                       module="insuree"
-                      readOnly={this.isNewInsuree||this.props.readOnly}
+                      readOnly={!edited?.uuid || readOnly}
                       onChange={(v) => this.updateAttributes({ "status": v, "statusReason": null })}
                       required={isInsureeStatusRequired}
                     />


### PR DESCRIPTION
[OP-1695](https://openimis.atlassian.net/browse/OP-1695)

Changes:
- Creating an insuree from the family overview page is possible now.

[OP-1695]: https://openimis.atlassian.net/browse/OP-1695?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ