### PR TITLE
OP-1699: if no family, update insuree and save family

### DIFF
--- a/src/components/InsureeForm.js
+++ b/src/components/InsureeForm.js
@@ -92,6 +92,11 @@ class InsureeForm extends Component {
         };
       });
     }
+
+    if (!this.state.insuree.family && this.props.family) {
+      const updatedInsuree = { ...this.state.insuree, family: this.props.family };
+      this.setState({ insuree: updatedInsuree });
+    }
   }
 
   componentWillUnmount = () => {


### PR DESCRIPTION
[OP-1699](https://openimis.atlassian.net/browse/OP-1699)

Changes:
- If insuree does not have family registered, use family fetched on mount.

[OP-1699]: https://openimis.atlassian.net/browse/OP-1699?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ