### PR TITLE
OP-1725: remove null/empty options from dropdowns

### DIFF
--- a/src/components/FamilyMasterPanel.js
+++ b/src/components/FamilyMasterPanel.js
@@ -133,9 +133,8 @@ class FamilyMasterPanel extends FormPanel {
           <Grid item xs={2} className={classes.item}>
             <PublishedComponent
               pubRef="insuree.FamilyTypePicker"
-              withNull={true}
+              withNull={false}
               readOnly={readOnly}
-              nullLabel={formatMessage(intl, "insuree", "Family.FamilyType.null")}
               value={!!edited && !!edited.familyType ? edited.familyType.code : null}
               onChange={(v) => this.updateAttribute("familyType", { code: v })}
             />
@@ -143,9 +142,8 @@ class FamilyMasterPanel extends FormPanel {
           <Grid item xs={2} className={classes.item}>
             <PublishedComponent
               pubRef="insuree.ConfirmationTypePicker"
-              withNull={true}
+              withNull={false}
               readOnly={readOnly}
-              nullLabel={formatMessage(intl, "insuree", "Family.ConfirmationType.null")}
               value={edited?.confirmationType ?? null}
               onChange={(v) => this.updateAttribute("confirmationType", v)}
             />
@@ -165,7 +163,6 @@ class FamilyMasterPanel extends FormPanel {
               module="insuree"
               label="Family.address"
               multiline
-              rows={2}
               readOnly={readOnly}
               value={!edited ? "" : edited.address}
               onChange={(v) => this.updateAttribute("address", v)}

--- a/src/components/InsureeMasterPanel.js
+++ b/src/components/InsureeMasterPanel.js
@@ -144,8 +144,7 @@ class InsureeMasterPanel extends FormPanel {
                       value={!!edited && !!edited.marital ? edited.marital : ""}
                       module="insuree"
                       readOnly={readOnly}
-                      withNull={true}
-                      nullLabel="InsureeMaritalStatus.N"
+                      withNull={false}
                       onChange={(v) => this.updateAttribute("marital", v)}
                     />
                   </Grid>
@@ -196,8 +195,7 @@ class InsureeMasterPanel extends FormPanel {
                       module="insuree"
                       value={!!edited && !!edited.profession ? edited.profession.id : null}
                       readOnly={readOnly}
-                      withNull={true}
-                      nullLabel={formatMessage(intl, "insuree", "Profession.none")}
+                      withNull={false}
                       onChange={(v) => this.updateAttribute("profession", { id: v })}
                     />
                   </Grid>
@@ -207,8 +205,7 @@ class InsureeMasterPanel extends FormPanel {
                       module="insuree"
                       value={!!edited && !!edited.education ? edited.education.id : ""}
                       readOnly={readOnly}
-                      withNull={true}
-                      nullLabel={formatMessage(intl, "insuree", "insuree.Education.none")}
+                      withNull={false}
                       onChange={(v) => this.updateAttribute("education", { id: v })}
                     />
                   </Grid>
@@ -218,8 +215,7 @@ class InsureeMasterPanel extends FormPanel {
                       module="insuree"
                       value={!!edited && !!edited.typeOfId ? edited.typeOfId.code : null}
                       readOnly={readOnly}
-                      withNull={true}
-                      nullLabel={formatMessage(intl, "insuree", "IdentificationType.none")}
+                      withNull={false}
                       onChange={(v) => this.updateAttribute("typeOfId", { code: v })}
                     />
                   </Grid>


### PR DESCRIPTION
[OP-1725](https://openimis.atlassian.net/browse/OP-1725)

Changes:

- Remove the 'none/null' option from the dropdowns menu in the form.

[OP-1725]: https://openimis.atlassian.net/browse/OP-1725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ