### PR TITLE
ONI-156: Added setting to set photo as required.

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,3 +97,4 @@ None
 - `insureeForm.isInsureeFirstServicePointRequired`, allow to set FSP to required while creating new insuree, default false.
 - `showInsureeSummaryAddress`, show insuree address information in enquire, default false.
 - `insureeForm.isInsureeStatusRequired`, make insuree status dropdown mandatory, default false.
+- `insureeForm.isInsureePhotoRequired`, make photo upload of an insuree mandatory, default false.

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -19,6 +19,12 @@ export const isValidInsuree = (insuree, modulesManager) => {
     false,
   );
 
+  const isInsureePhotoRequired = modulesManager.getConf(
+    "fe-insuree",
+    "insureeForm.isInsureePhotoRequired",
+    false,
+  );
+
   const isInsureeStatusRequired = modulesManager.getConf("fe-insuree", "insureeForm.isInsureeStatusRequired", false);
 
   if (isInsureeFirstServicePointRequired && !insuree.healthFacility) return false;
@@ -30,6 +36,7 @@ export const isValidInsuree = (insuree, modulesManager) => {
   if (!insuree.gender || !insuree.gender?.code) return false;
   if (!!insuree.photo && (!insuree.photo.date || !insuree.photo.officerId)) return false;
   if (isInsureeStatusRequired && !insuree.status) return false;
+  if (isInsureePhotoRequired && !insuree.photo) return false;
   if (!!insuree.status && insuree.status !== INSUREE_ACTIVE_STRING && (!insuree.statusDate || !insuree.statusReason)) return false;
 
   return true;


### PR DESCRIPTION
Ticket: https://openimis.atlassian.net/browse/ONI-156

BE check: https://github.com/openimis/openimis-be-insuree_py/pull/114

Changes:
- Added setting for photo to be required
- If required - saving is blocked without photo, but no indication in form - non-standard field.