### PR TITLE
OM-113: remove family button is isWorker true

### DIFF
--- a/src/components/InsureeSearcher.js
+++ b/src/components/InsureeSearcher.js
@@ -203,7 +203,7 @@ class InsureeSearcher extends Component {
             </Grid>
               )}
 
-          {insuree.family && (
+          {!this.isWorker && insuree.family &&  (
             <Grid item>
               <Tooltip title={formatMessage(this.props.intl, "insuree", "insureeSummaries.openFamilyButton.tooltip")}>
                 <IconButton


### PR DESCRIPTION
[OM-113](https://openimis.atlassian.net/browse/OM-113)

Changes:
- If _isWorker_ true, do not display a family link button.

[OM-113]: https://openimis.atlassian.net/browse/OM-113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ