### PR TITLE
OP-1748: add placeholder notfound

### DIFF
--- a/src/pickers/InsureeChfIdPicker.js
+++ b/src/pickers/InsureeChfIdPicker.js
@@ -1,11 +1,13 @@
 import React, { Component } from "react";
 import { connect } from "react-redux";
+import { injectIntl } from "react-intl";
 import { bindActionCreators } from "redux";
 import { Grid } from "@material-ui/core";
-import { withModulesManager, TextInput, ProgressOrError } from "@openimis/fe-core";
+import { withModulesManager, TextInput, ProgressOrError, formatMessage } from "@openimis/fe-core";
 
 import { fetchInsuree } from "../actions";
 import _debounce from "lodash/debounce";
+import { EMPTY_STRING } from "../constants";
 
 const INIT_STATE = {
   search: "",
@@ -59,7 +61,13 @@ class InsureeChfIdPicker extends Component {
   debouncedSearch = _debounce(this.fetch, this.props.modulesManager.getConf("fe-insuree", "debounceTime", 800));
 
   formatInsuree(insuree) {
-    if (!insuree) return "";
+    const { search } = this.state;
+    const { intl } = this.props;
+
+    if (!insuree) {
+      return search === EMPTY_STRING ? EMPTY_STRING : formatMessage(intl, "insuree", "notFound");
+    }
+
     return `${insuree.otherNames} ${insuree.lastName}`;
   }
 
@@ -107,4 +115,4 @@ const mapDispatchToProps = (dispatch) => {
   return bindActionCreators({ fetchInsuree }, dispatch);
 };
 
-export default withModulesManager(connect(mapStateToProps, mapDispatchToProps)(InsureeChfIdPicker));
+export default withModulesManager(injectIntl(connect(mapStateToProps, mapDispatchToProps)(InsureeChfIdPicker)));


### PR DESCRIPTION
[OP-1748](https://openimis.atlassian.net/browse/OP-1748)

Changes:
- If insuree not found, instead of empty field, display 'Not Found' placeholder.
![image](https://github.com/openimis/openimis-fe-insuree_js/assets/109145288/f6452ae2-6397-4819-93fc-7e6f9b757cf2)


[OP-1748]: https://openimis.atlassian.net/browse/OP-1748?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ