### PR TITLE
OM-118: add workers export functionality

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -40,7 +40,7 @@ const FAMILY_HEAD_PROJECTION = (mm) => [
   "email",
   "phone",
   "healthFacility" + mm.getProjection("location.HealthFacilityPicker.projection"),
-]
+];
 
 const FAMILY_FULL_PROJECTION = (mm) => [
   "id",
@@ -122,9 +122,9 @@ export function fetchInsuree(mm, chfid) {
   return graphql(payload, "INSUREE_INSUREE");
 }
 
-export function fetchInsureeFull(mm, uuid, ignoreLocation=false) {
+export function fetchInsureeFull(mm, uuid, ignoreLocation = false) {
   let args = [`uuid:"${uuid}"`];
-  if (ignoreLocation) args.push('ignoreLocation: true');
+  if (ignoreLocation) args.push("ignoreLocation: true");
   let payload = formatPageQuery("insurees", args, INSUREE_FULL_PROJECTION(mm), "clientMutationId");
   return graphql(payload, "INSUREE_INSUREE");
 }
@@ -243,8 +243,8 @@ export function fetchRelations(mm) {
   return graphql(payload, "INSUREE_RELATIONS");
 }
 
-export function fetchInsureeSummaries(mm, filters, ignoreLocation=false) {
-  if (ignoreLocation) filters.push('ignoreLocation: true');
+export function fetchInsureeSummaries(mm, filters, ignoreLocation = false) {
+  if (ignoreLocation) filters.push("ignoreLocation: true");
   var projections = [
     "id",
     "uuid",
@@ -304,11 +304,7 @@ export function formatInsureeGQL(mm, insuree) {
     ${!!insuree.family && !!insuree.family.id ? `familyId: ${decodeId(insuree.family.id)}` : ""}
     ${!!insuree.relationship && !!insuree.relationship.id ? `relationshipId: ${insuree.relationship.id}` : ""}
     ${!!insuree.status ? `status: "${insuree.status}"` : ""}
-    ${
-      !!insuree.statusDate && !!insuree.status != INSUREE_ACTIVE_STRING
-        ? `statusDate: "${insuree.statusDate}"`
-        : ""
-    }
+    ${!!insuree.statusDate && !!insuree.status != INSUREE_ACTIVE_STRING ? `statusDate: "${insuree.statusDate}"` : ""}
     ${
       !!insuree.statusReason && !!insuree.status != INSUREE_ACTIVE_STRING
         ? `statusReason: "${insuree.statusReason.code}"`
@@ -501,5 +497,21 @@ export function checkIfHeadSelected(insuree) {
 
   return (dispatch) => {
     dispatch({ type: "INSUREE_CHECK_IS_HEAD_SELECTED", payload: { headSelected } });
+  };
+}
+
+export function downloadWorkers(params) {
+  const payload = `
+  {
+    insureesExport${!!params && params.length ? `(${params.join(",")})` : ""}
+  }`;
+  return graphql(payload, "WORKERS_EXPORT");
+}
+
+export function clearWorkersExport() {
+  return (dispatch) => {
+    dispatch({
+      type: "WORKERS_EXPORT_CLEAR",
+    });
   };
 }

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -62,6 +62,11 @@ function reducer(
     submittingMutation: false,
     headSelected: false,
     mutation: {},
+    fetchingWorkersExport: false,
+    fetchedWorkersExport: false,
+    workersExport: null,
+    workersExportPageInfo: {},
+    errorWorkersExport: null,
   },
   action,
 ) {
@@ -492,6 +497,39 @@ function reducer(
       return {
         ...state,
         headSelected: action.payload?.headSelected,
+      };
+    case "WORKERS_EXPORT_REQ":
+      return {
+        ...state,
+        fetchingWorkersExport: true,
+        fetchedWorkersExport: false,
+        workersExport: null,
+        workersExportPageInfo: {},
+        errorWorkersExport: null,
+      };
+    case "WORKERS_EXPORT_RESP":
+      return {
+        ...state,
+        fetchingWorkersExport: false,
+        fetchedWorkersExport: true,
+        workersExport: action.payload.data.insureesExport,
+        workersExportPageInfo: pageInfo(action.payload.data.insureesExportPageInfo),
+        errorWorkersExport: formatGraphQLError(action.payload),
+      };
+    case "WORKERS_EXPORT_ERR":
+      return {
+        ...state,
+        fetchingWorkersExport: false,
+        errorWorkersExport: formatServerError(action.payload),
+      };
+    case "WORKERS_EXPORT_CLEAR":
+      return {
+        ...state,
+        fetchingWorkersExport: false,
+        fetchedWorkersExport: false,
+        workersExport: null,
+        workersExportPageInfo: {},
+        errorWorkersExport: null,
       };
     case "INSUREE_MUTATION_REQ":
       return dispatchMutationReq(state, action);

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -6,6 +6,8 @@
   "insuree.menu.familiesOrGroups": "Families/Groups",
   "insuree.menu.insurees": "Insurees",
   "insuree.menu.workers": "Workers",
+  "insuree.workers.filename": "workers_export",
+  "insuree.workers.export": "DOWNLOAD WORKERS",
   "insuree.ageUnit": "Years",
   "insuree.label.regionFSP": "Region of FSP",
   "insuree.label.districtFSP": "District of FSP",


### PR DESCRIPTION
[OM-118](https://openimis.atlassian.net/browse/OM-118)

[CORE BE PR](https://github.com/openimis/openimis-be-core_py/pull/253)
[INSUREE BE PR](https://github.com/openimis/openimis-be-insuree_py/pull/117)

Changes:
- Add a "Download Workers" button to export all worker search results.
- Lokalise keys have been updated.





[OM-118]: https://openimis.atlassian.net/browse/OM-118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ