### PR TITLE
ONI-30: fix issue with insuree picker and alert dialog

### DIFF
--- a/src/components/FamilyInsureesOverview.js
+++ b/src/components/FamilyInsureesOverview.js
@@ -72,7 +72,7 @@ class FamilyInsureesOverview extends PagedDataHandler {
     removeInsuree: null,
     changeInsureeFamily: null,
     reset: 0,
-    canAddAction: null,
+    canAddAction: () => null,
     checkedCanAdd: false,
     filters: {},
     showInsureeSearcher: false,
@@ -138,8 +138,6 @@ class FamilyInsureesOverview extends PagedDataHandler {
         messages.push(formatMessage(this.props.intl, "insuree", "addInsuree.alert.message"));
         this.props.coreAlert(formatMessage(this.props.intl, "insuree", "addInsuree.alert.title"), messages);
       }
-    } else if (!!prevProps.alert && !this.props.alert) {
-      this.setState({ checkedCanAdd: true }, (e) => this.state.canAddAction());
     }
     if (this.state.filters !== prevState.filters) {
       this.query();


### PR DESCRIPTION
[ONI-30](https://openimis.atlassian.net/browse/ONI-30)

RELATED PRs:
https://github.com/openimis/openimis-fe-contribution_js/pull/40
https://github.com/openimis/openimis-fe-policy_js/pull/83

Changes:
- Do not show InsureePicker when displaying any other alert dialog.