### PR TITLE
OM-122: make generic vouchers configurable

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -29,6 +29,7 @@ export const DEFAULT = {
   SHOW_INSUREE_SUMMARY_ADDRESS: false,
   IS_WORKER: false,
   RENDER_LAST_NAME_FIRST: true,
+  GENERIC_VOUCHER_ENABLED: false,
 };
 
 export const WITHOUT_STR = "without"

--- a/src/menus/InsureeMainMenu.js
+++ b/src/menus/InsureeMainMenu.js
@@ -12,6 +12,11 @@ class InsureeMainMenu extends Component {
   constructor(props) {
     super(props);
     this.isWorker = props.modulesManager.getConf("fe-insuree", "isWorker", DEFAULT.IS_WORKER);
+    this.genericVoucherEnabled = props.modulesManager.getConf(
+      "fe-worker_voucher",
+      "genericVoucherEnabled",
+      DEFAULT.GENERIC_VOUCHER_ENABLED,
+    );
   }
 
   render() {
@@ -19,6 +24,8 @@ class InsureeMainMenu extends Component {
     let entries = [];
 
     if (this.isWorker) {
+      const config = { genericVoucherEnabled: this.genericVoucherEnabled };
+
       if (rights.includes(RIGHT_WORKER)) {
         entries.push({
           text: formatMessage(this.props.intl, "insuree", "menu.workers"),
@@ -26,10 +33,11 @@ class InsureeMainMenu extends Component {
           route: `/${modulesManager.getRef("insuree.route.insurees")}`,
         });
       }
+      
       entries.push(
         ...this.props.modulesManager
           .getContribs(WORKER_MAIN_MENU_CONTRIBUTION_KEY)
-          .filter((c) => !c.filter || c.filter(rights)),
+          .filter((c) => !c.filter || c.filter(rights, config)),
       );
 
       if (!entries) return null;


### PR DESCRIPTION
[OM-122](https://openimis.atlassian.net/browse/OM-122)

[RELATED PR](https://github.com/openimis/openimis-fe-worker_voucher_js/pull/25)

Changes:
- Make rendering routes configurable based on config, not only on rights.

[OM-122]: https://openimis.atlassian.net/browse/OM-122?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ