### PR TITLE
OP-1817: hide validity dates if historical data not requested

### DIFF
--- a/src/components/FamilySearcher.js
+++ b/src/components/FamilySearcher.js
@@ -93,8 +93,8 @@ class FamilySearcher extends Component {
     h.push(
       "insuree.familySummaries.poverty",
       "insuree.familySummaries.confirmationNo",
-      "insuree.familySummaries.validityFrom",
-      "insuree.familySummaries.validityTo",
+      filters?.showHistory?.value ? "insuree.familySummaries.validityFrom" : null,
+      filters?.showHistory?.value ? "insuree.familySummaries.validityTo" : null,
       "insuree.familySummaries.openNewTab",
     );
     if (!!this.props.rights.includes(RIGHT_FAMILY_DELETE)) {
@@ -176,8 +176,12 @@ class FamilySearcher extends Component {
     formatters.push(
       (family) => <Checkbox color="primary" checked={family.poverty} readOnly />,
       (family) => family.confirmationNo,
-      (family) => formatDateFromISO(this.props.modulesManager, this.props.intl, family.validityFrom),
-      (family) => formatDateFromISO(this.props.modulesManager, this.props.intl, family.validityTo),
+      filters?.showHistory?.value
+        ? (family) => formatDateFromISO(this.props.modulesManager, this.props.intl, family.validityFrom)
+        : null,
+      filters?.showHistory?.value
+        ? (family) => formatDateFromISO(this.props.modulesManager, this.props.intl, family.validityTo)
+        : null,
       (family) => (
         <Tooltip title={formatMessage(this.props.intl, "insuree", "familySummaries.openNewTabButton.tooltip")}>
           <IconButton onClick={(e) => !family.clientMutationId && this.props.onDoubleClick(family, true)}>

--- a/src/components/InsureeSearcher.js
+++ b/src/components/InsureeSearcher.js
@@ -118,8 +118,8 @@ class InsureeSearcher extends Component {
       this.isWorker ? null : "insuree.insureeSummaries.phone",
       this.isWorker ? null : "insuree.insureeSummaries.dob",
       ...Array.from(Array(this.locationLevels)).map((_, i) => (this.isWorker ? null : `location.locationType.${i}`)),
-      "insuree.insureeSummaries.validityFrom",
-      filters.showHistory && "insuree.insureeSummaries.validityTo",
+      filters?.showHistory?.value ? "insuree.insureeSummaries.validityFrom" : null,
+      filters?.showHistory?.value ? "insuree.insureeSummaries.validityTo" : null,
       "",
     ];
     return h.filter(Boolean);
@@ -135,9 +135,10 @@ class InsureeSearcher extends Component {
       ["email", true],
       ["phone", true],
       ["dob", true],
+      filters?.showHistory?.value ? ["validityFrom", false] : null,
+      filters?.showHistory?.value ? ["validityTo", false] : null,
     ];
     _.times(this.locationLevels, () => results.push(null));
-    results.push(["validityFrom", false], ["validityTo", false]);
     return results;
   };
 
@@ -218,9 +219,12 @@ class InsureeSearcher extends Component {
       }
     }
     formatters.push(
-      (insuree) => formatDateFromISO(this.props.modulesManager, this.props.intl, insuree.validityFrom),
-      filters.showHistory &&
-        ((insuree) => formatDateFromISO(this.props.modulesManager, this.props.intl, insuree.validityTo)),
+      filters?.showHistory?.value
+        ? (insuree) => formatDateFromISO(this.props.modulesManager, this.props.intl, insuree.validityFrom)
+        : null,
+      filters?.showHistory?.value
+        ? (insuree) => formatDateFromISO(this.props.modulesManager, this.props.intl, insuree.validityTo)
+        : null,
       (insuree) => (
         <Grid container wrap="nowrap" spacing="2">
           {!this.isWorker && (


### PR DESCRIPTION
[OP-1817](https://openimis.atlassian.net/browse/OP-1817)

Changes:

- InsureeSearcher | FamilySearcher : Show or hide "Validity From" and "Validity To" columns based on the showHistory filter.

[OP-1817]: https://openimis.atlassian.net/browse/OP-1817?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ