### PR TITLE
OP-1818: pass min/max date properly

### DIFF
--- a/src/components/InsureeFilter.js
+++ b/src/components/InsureeFilter.js
@@ -298,6 +298,7 @@ class InsureeFilter extends Component {
                                   value={this._filterValue("dobFrom")}
                                   module="insuree"
                                   label="Insuree.dobFrom"
+                                  {...(filters.dobTo ? { maxDate: filters.dobTo.value } : null)}
                                   onChange={(d) =>
                                       onChangeFilters([
                                           {
@@ -315,7 +316,7 @@ class InsureeFilter extends Component {
                                   value={this._filterValue("dobTo")}
                                   module="insuree"
                                   label="Insuree.dobTo"
-                                  minDate={filters?.dobFrom}
+                                  {...(filters.dobFrom ? { minDate: filters.dobFrom.value } : null)}
                                   onChange={(d) =>
                                       onChangeFilters([
                                           {


### PR DESCRIPTION
[OP-1818](https://openimis.atlassian.net/browse/OP-1818)

Changes:
 - Fix the _InsureeFilter_ to accurately filter dates, ensuring it does not cause crashes in the secondary calendar functionality.

[OP-1818]: https://openimis.atlassian.net/browse/OP-1818?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ