### PR TITLE
OM-131: change isWorker source

### DIFF
--- a/src/components/InsureeFilter.js
+++ b/src/components/InsureeFilter.js
@@ -32,7 +32,7 @@ const INSUREE_FILTER_CONTRIBUTION_KEY = "insuree.Filter";
 class InsureeFilter extends Component {
     constructor(props) {
         super(props);
-        this.isWorker = props.modulesManager.getConf("fe-insuree", "isWorker", DEFAULT.IS_WORKER);
+        this.isWorker = props.modulesManager.getConf("fe-core", "isWorker", DEFAULT.IS_WORKER);
         this.renderLastNameFirst = props.modulesManager.getConf("fe-insuree", "renderLastNameFirst", DEFAULT.RENDER_LAST_NAME_FIRST);
     }
   debouncedOnChangeFilter = _debounce(

--- a/src/components/InsureeForm.js
+++ b/src/components/InsureeForm.js
@@ -41,7 +41,7 @@ class InsureeForm extends Component {
       newInsuree: true,
       isSaved: false,
     };
-    this.isWorker = props.modulesManager.getConf("fe-insuree", "isWorker", DEFAULT.IS_WORKER);
+    this.isWorker = props.modulesManager.getConf("fe-core", "isWorker", DEFAULT.IS_WORKER);
   }
 
   _newInsuree() {

--- a/src/components/InsureeSearcher.js
+++ b/src/components/InsureeSearcher.js
@@ -53,7 +53,7 @@ class InsureeSearcher extends Component {
     );
     this.defaultPageSize = props.modulesManager.getConf("fe-insuree", "insureeFilter.defaultPageSize", 10);
     this.locationLevels = this.props.modulesManager.getConf("fe-location", "location.Location.MaxLevels", 4);
-    this.isWorker = props.modulesManager.getConf("fe-insuree", "isWorker", DEFAULT.IS_WORKER);
+    this.isWorker = props.modulesManager.getConf("fe-core", "isWorker", DEFAULT.IS_WORKER);
     this.renderLastNameFirst = props.modulesManager.getConf(
       "fe-insuree",
       "renderLastNameFirst",

--- a/src/menus/InsureeMainMenu.js
+++ b/src/menus/InsureeMainMenu.js
@@ -11,7 +11,7 @@ const WORKER_MAIN_MENU_CONTRIBUTION_KEY = "worker.MainMenu";
 class InsureeMainMenu extends Component {
   constructor(props) {
     super(props);
-    this.isWorker = props.modulesManager.getConf("fe-insuree", "isWorker", DEFAULT.IS_WORKER);
+    this.isWorker = props.modulesManager.getConf("fe-core", "isWorker", DEFAULT.IS_WORKER);
     this.genericVoucherEnabled = props.modulesManager.getConf(
       "fe-worker_voucher",
       "genericVoucherEnabled",


### PR DESCRIPTION
[OM-131](https://openimis.atlassian.net/browse/OM-131)

Changes:
- Change isWorker source from "fe-insuree" to "fe-core" as it is used across multiple modules.

[OM-131]: https://openimis.atlassian.net/browse/OM-131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ