### PR TITLE
OP-1712: changed status of the family to be fetched from insuree assigned family

### DIFF
--- a/src/components/FamilyDisplayPanel.js
+++ b/src/components/FamilyDisplayPanel.js
@@ -49,7 +49,7 @@ const mapStateToProps = (state, props) => ({
   fetchingFamily: state.insuree.fetchingFamily,
   errorFamily: state.insuree.errorFamily,
   fetchedFamily: state.insuree.fetchedFamily,
-  family: state.insuree.family,
+  family: state.insuree?.insuree?.family,
 });
 
 const mapDispatchToProps = (dispatch) => {


### PR DESCRIPTION
Ticket:
https://openimis.atlassian.net/browse/OP-1712

Changes:
- family panel is now being displayed based of the family assigned to insuree not the family in the insuree state

How was it tested?
1. Reproduce bug:
- go to family/group '174000001'
- add member: '174000002'
- delete member from family, keep/delete policy
- go to insuree
- the family detail page is not visible anymore