### PR TITLE
OP-2065: do not send photo when no update on it

### DIFF
--- a/src/components/InsureeForm.js
+++ b/src/components/InsureeForm.js
@@ -205,7 +205,9 @@ class InsureeForm extends Component {
   };
 
   _save = (insuree) => {
-    if (!this.doesPhotoChange()) delete insuree.photo 
+    if (insuree.uuid) {
+      if (!this.doesPhotoChange()) delete insuree.photo
+    }
     this.setState({ lockNew: !insuree.id, isSaved: true }, 
     (e) => this.props.save(insuree));
   };

--- a/src/components/InsureeForm.js
+++ b/src/components/InsureeForm.js
@@ -187,6 +187,14 @@ class InsureeForm extends Component {
     return true;
   };
 
+  doesPhotoChange = () => {
+    const { insuree } = this.props;
+    if (_.isEqual(insuree.photo, this.state.insuree.photo)) {
+      return false;
+    }
+    return true;
+  };
+
   canSave = () => {
     const doesInsureeChange = this.doesInsureeChange();
     if (!doesInsureeChange) return false;
@@ -197,7 +205,9 @@ class InsureeForm extends Component {
   };
 
   _save = (insuree) => {
-    this.setState({ lockNew: !insuree.id, isSaved: true }, (e) => this.props.save(insuree));
+    if (!this.doesPhotoChange()) delete insuree.photo 
+    this.setState({ lockNew: !insuree.id, isSaved: true }, 
+    (e) => this.props.save(insuree));
   };
 
   onEditedChanged = (insuree) => {


### PR DESCRIPTION
TICKET: https://openimis.atlassian.net/browse/OP-2065

Fixes:
- when photo is not changed in update mode - do not send it in update payload
- added mechanism to check 'create' mode too during photo deletion from update payload when photo is not changed 