### PR TITLE
OP-2323: new enquiry state

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -123,6 +123,37 @@ export function fetchInsuree(mm, chfid) {
   return graphql(payload, "INSUREE_INSUREE");
 }
 
+export function fetchInsureeEnquiry(mm, chfid) {
+  let payload = formatPageQuery(
+    "insurees",
+    [`chfId:"${chfid}", ignoreLocation:true`],
+    [
+      "id",
+      "uuid",
+      "chfId",
+      "lastName",
+      "otherNames",
+      "dob",
+      "age",
+      "validityFrom",
+      "validityTo",
+      "gender{code}",
+      "status",
+      `family{${FAMILY_FULL_PROJECTION(mm).join(",")}}`,
+      "photo{folder,filename,photo}",
+      "gender{code, gender, altLanguage}",
+      "healthFacility" + mm.getProjection("location.HealthFacilityPicker.projection"),
+    ],
+  );
+  return graphql(payload, "ENQUIRY_INSUREE");
+}
+
+export function clearInsureeEnquiry() {
+  return (dispatch) => {
+    dispatch({ type: "ENQUIRY_INSUREE_CLEAR" });
+  };
+}
+
 export function fetchInsureeFull(mm, uuid, ignoreLocation = false) {
   let args = [`uuid:"${uuid}"`];
   if (ignoreLocation) args.push("ignoreLocation: true");

--- a/src/components/EnquiryDialog.js
+++ b/src/components/EnquiryDialog.js
@@ -15,7 +15,7 @@ import {
   withModulesManager,
   withHistory,
 } from "@openimis/fe-core";
-import { fetchInsuree } from "../actions";
+import { fetchInsureeEnquiry, clearInsureeEnquiry } from "../actions";
 import InsureeSummary from "./InsureeSummary";
 
 const useStyles = makeStyles(() => ({
@@ -27,7 +27,8 @@ const useStyles = makeStyles(() => ({
 const EnquiryDialog = ({
   intl,
   modulesManager,
-  fetchInsuree,
+  fetchInsureeEnquiry,
+  clearInsureeEnquiry,
   fetching,
   fetched,
   insuree,
@@ -40,12 +41,18 @@ const EnquiryDialog = ({
   const classes = useStyles();
   const prevMatchUrl = useRef(null);
 
+  const handleClose = () => {
+    clearInsureeEnquiry();
+    onClose();
+  };
+
   useEffect(() => {
     if (open && insuree?.id !== chfid) {
-      fetchInsuree(modulesManager, chfid);
+      fetchInsureeEnquiry(modulesManager, chfid);
     }
 
     if (!!match?.url && match.url !== prevMatchUrl.current) {
+      clearInsureeEnquiry();
       onClose();
     }
 
@@ -79,7 +86,7 @@ const EnquiryDialog = ({
         )}
       </DialogContent>
       <DialogActions>
-        <Button onClick={onClose} color="primary">
+        <Button onClick={handleClose} color="primary">
           {formatMessage(intl, "insuree", "close")}
         </Button>
       </DialogActions>
@@ -88,11 +95,11 @@ const EnquiryDialog = ({
 };
 
 const mapStateToProps = (state) => ({
-  fetching: state.insuree.fetchingInsuree,
-  fetched: state.insuree.fetchedInsuree,
-  insuree: state.insuree.insuree,
-  error: state.insuree.errorInsuree,
+  fetching: state.insuree?.fetchingInsureeEnquiry,
+  fetched: state.insuree?.fetchedInsureeEnquiry,
+  insuree: state.insuree?.insureeEnquiry,
+  error: state.insuree?.errorInsureeEnquiry,
 });
 
-const mapDispatchToProps = (dispatch) => bindActionCreators({ fetchInsuree }, dispatch);
+const mapDispatchToProps = (dispatch) => bindActionCreators({ fetchInsureeEnquiry, clearInsureeEnquiry }, dispatch);
 export default withModulesManager(withHistory(connect(mapStateToProps, mapDispatchToProps)(injectIntl(EnquiryDialog))));

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -14,6 +14,7 @@ function reducer(
     fetchedInsuree: false,
     errorInsuree: null,
     insuree: null,
+    insureeEnquiry: null,
     fetchingInsureeFamilyMembers: false,
     fetchedInsureeFamilyMembers: false,
     errorInsureeFamilyMembers: null,
@@ -95,6 +96,36 @@ function reducer(
         fetchedInsuree: false,
         insuree: null,
         errorInsuree: null,
+      };
+    case "ENQUIRY_INSUREE_REQ":
+      return {
+        ...state,
+        fetchingInsureeEnquiry: true,
+        fetchedInsureeEnquiry: false,
+        insureeEnquiry: null,
+        errorInsureeEnquiry: null,
+      };
+    case "ENQUIRY_INSUREE_RESP":
+      return {
+        ...state,
+        fetchingInsureeEnquiry: false,
+        fetchedInsureeEnquiry: true,
+        insureeEnquiry: parseData(action.payload.data.insurees)[0],
+        errorInsureeEnquiry: formatGraphQLError(action.payload),
+      };
+    case "ENQUIRY_INSUREE_ERR":
+      return {
+        ...state,
+        fetchedInsureeEnquiry: false,
+        errorInsureeEnquiry: formatServerError(action.payload),
+      };
+    case "ENQUIRY_INSUREE_CLEAR":
+      return {
+        ...state,
+        fetchingInsureeEnquiry: false,
+        fetchedInsureeEnquiry: false,
+        insureeEnquiry: null,
+        errorInsureeEnquiry: null,
       };
     case "INSUREE_FAMILY_NEW":
       return {


### PR DESCRIPTION
Related PR:
https://github.com/openimis/openimis-fe-policy_js/pull/95

Ticket:
https://openimis.atlassian.net/browse/OP-2323

Changes:
- enquiry function now has new reducers to fetch insuree data but into different state
-

Test:
1. It does not overwrite the claim insuree info, Policy of Insuree and Remain Counts and Remain Amounts are visible.


