### PR TITLE
feat: Improve Enrolment Officer Selection When Adding Insuree Photo #OP-2527

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,3 +99,4 @@ None
 - `showInsureeSummaryAddress`, show insuree address information in enquire, default false.
 - `insureeForm.isInsureeStatusRequired`, make insuree status dropdown mandatory, default false.
 - `insureeForm.isInsureePhotoRequired`, make photo upload of an insuree mandatory, default false.
+- `isCurrentAdminEnrollmentOfficerActive`, make the Insuree Officer dropdown read-only and automatically select the currently logged-in user if they have the Enrollment Officer role.

--- a/src/actions.js
+++ b/src/actions.js
@@ -208,8 +208,8 @@ export function fetchInsureeMutation(mm, clientMutationId) {
   return graphql(payload, "INSUREE_INSUREE");
 }
 
-export function fetchInsureeOfficers(mm) {
-  const payload = formatPageQuery("insureeOfficers", null, mm.getRef("insuree.InsureeOfficerPicker.projection"));
+export function fetchInsureeOfficers(mm, filters) {
+  const payload = formatPageQuery("insureeOfficers", filters, mm.getRef("insuree.InsureeOfficerPicker.projection"));
   return graphql(payload, "INSUREE_INSUREE_OFFICERS");
 }
 

--- a/src/components/InsureeAddress.js
+++ b/src/components/InsureeAddress.js
@@ -24,6 +24,7 @@ const InsureeAddress = ({
   onChangeAddress,
   readOnly,
   value,
+  onChangeSameLocationCheckbox,
 }) => {
   const classes = useStyles();
   const modulesManager = useModulesManager();
@@ -31,6 +32,12 @@ const InsureeAddress = ({
 
   const [location, setLocation] = useState(true);
   const [address, setAddress] = useState(true);
+
+  const handleLocationChange = (e) => {
+    const checked = e.target.checked;
+    onChangeSameLocationCheckbox(checked)
+    setLocation(checked);
+  };
 
   return (
     <Grid container>
@@ -41,7 +48,7 @@ const InsureeAddress = ({
               color="primary"
               checked={location}
               disabled={readOnly}
-              onChange={(e) => setLocation((prevState) => !prevState)}
+              onChange={(e) =>handleLocationChange(e)}
             />
           }
           label={formatMessage("Insuree.currentVillage.sameAsFamily")}

--- a/src/components/InsureeAvatar.js
+++ b/src/components/InsureeAvatar.js
@@ -17,7 +17,7 @@ const styles = (theme) => ({
 });
 
 const InsureeAvatar = (props) => {
-  const { photo, classes, className, withMeta = false, readOnly, onChange } = props;
+  const { photo, classes, className, withMeta = false, readOnly, onChange, locationId } = props;
   const modulesManager = useModulesManager();
   const { formatMessage } = useTranslations("insuree", modulesManager);
 
@@ -91,6 +91,7 @@ const InsureeAvatar = (props) => {
               readOnly={readOnly}
               required={isRequired}
               onChange={(v) => onChange({ ...photo, officerId: v?.id })}
+              locationId = {locationId}
             />
           </Grid>
         </Grid>

--- a/src/components/InsureeMasterPanel.js
+++ b/src/components/InsureeMasterPanel.js
@@ -67,7 +67,20 @@ class InsureeMasterPanel extends FormPanel {
       />
     </Grid>
   );
+  getLocationId = (insuree, family) => {
+    const { sameLocation } = this.props.edited || {};
+    const { edited } = this.props || {}
+    if (sameLocation == false) {
+      if (insuree?.currentVillage?.id) return insuree.currentVillage.id;
+      if (family?.headInsuree?.currentVillage?.id) return family.headInsuree.currentVillage.id;
+      if (edited?.currentVillage?.id) return edited.currentVillage.id;
+    }
 
+    if (family?.location?.id) return family.location.id;
+    if (insuree?.family?.location?.id) return insuree.family.location.id;
+
+    return "";
+  };
   render() {
     const {
       intl,
@@ -78,7 +91,11 @@ class InsureeMasterPanel extends FormPanel {
       readOnly = true,
       actions,
       editedId,
+      family,
+      insuree
     } = this.props;
+
+    const locationId = this.getLocationId(insuree, family);
 
     return (
       <Grid container>
@@ -199,6 +216,7 @@ class InsureeMasterPanel extends FormPanel {
                       readOnly={readOnly}
                       onChangeLocation={(v) => this.updateAttribute("currentVillage", v)}
                       onChangeAddress={(v) => this.updateAttribute("currentAddress", v)}
+                      onChangeSameLocationCheckbox={(v) =>this.updateAttribute("sameLocation", v)}
                     />
                   </Grid>
                   <Grid item xs={6} className={classes.item}>
@@ -307,6 +325,7 @@ class InsureeMasterPanel extends FormPanel {
                   readOnly={readOnly}
                   withMeta={true}
                   onChange={(v) => this.updateAttribute("photo", !!v ? v : null)}
+                  locationId={locationId}
                 />
               </Grid>
               <Contributions

--- a/src/pickers/InsureeOfficerPicker.js
+++ b/src/pickers/InsureeOfficerPicker.js
@@ -25,12 +25,35 @@ class InsureeOfficer extends Component {
   }
 
   componentDidMount() {
-    if (!this.props.fetchedInsureeOfficers) {
-      // prevent loading multiple times the cache when component is
-      // several times on tha page
+   if (!this.props.fetchedInsureeOfficers || !this.isCurrentAdminEnrollmentOfficerActive == false) {
+      const filters = [];
+      !!this.props.locationId && this.props.locationId != "" ? filters.push(`locationId:"${decodeId(this.props.locationId)}"`) : filters;
+
       setTimeout(() => {
-        !this.props.fetchingInsureeOfficers && this.props.fetchInsureeOfficers(this.props.modulesManager);
+        !this.props.fetchingInsureeOfficers && this.props.fetchInsureeOfficers(this.props.modulesManager, filters);
       }, Math.floor(Math.random() * 300));
+    }
+  }
+
+    componentDidUpdate(prevProps) {
+    // Recharger les données si locationId change
+    if (this.props.locationId !== prevProps.locationId) {
+      const { locationId } = this.props
+      const filters = [];
+      if (locationId != undefined && locationId != "" ) {
+        filters.push(`locationId:"${decodeId(locationId)}"`)
+      }
+      this.props.fetchInsureeOfficers(this.props.modulesManager, filters);
+    }
+
+    if (this.isCurrentAdminEnrollmentOfficerActive == true &&
+      this.props.insureeOfficers !== prevProps.insureeOfficers &&
+      this.props.insureeOfficers &&
+      this.props.insureeOfficers.length > 0 && this.isEnrollmentAdminOfficer(this.props.user, this.props.insureeOfficers)) {
+      this.props.onChange(
+        this.props.insureeOfficers[0],
+        this.formatSuggestion(this.props.insureeOfficers[0])
+      );
     }
   }
 
@@ -44,6 +67,11 @@ class InsureeOfficer extends Component {
     return `${a.code} ${fullName}`.trim();
   };
 
+  isEnrollmentAdminOfficer = (user, insureeOfficers) => {
+    if (!insureeOfficers || !user) return false;
+    if (user.username.trim() === insureeOfficers[0].code.trim()) return true;
+    else return false
+  }
   onSuggestionSelected = (v) => this.props.onChange(v, this.formatSuggestion(v));
 
   render() {
@@ -61,8 +89,9 @@ class InsureeOfficer extends Component {
       required = false,
       withNull = false,
       nullLabel = null,
+      user,
     } = this.props;
-    let v = insureeOfficers ? insureeOfficers.filter((o) => parseInt(decodeId(o.id)) === value) : [];
+    let v = (insureeOfficers ? insureeOfficers.filter((o) => parseInt(decodeId(o.id)) === value) : []);
     v = v.length ? v[0] : null;
     return (
       <Fragment>
@@ -75,9 +104,9 @@ class InsureeOfficer extends Component {
             getSuggestions={this.insureeOfficers}
             getSuggestionValue={this.formatSuggestion}
             onSuggestionSelected={this.onSuggestionSelected}
-            value={v}
+            value={this.isCurrentAdminEnrollmentOfficerActive == true && this.isEnrollmentAdminOfficer(user, insureeOfficers) ? insureeOfficers[0] : v}
             reset={reset}
-            readOnly={readOnly}
+            readOnly={this.isCurrentAdminEnrollmentOfficerActive == true && this.isEnrollmentAdminOfficer(user, insureeOfficers) ? true : readOnly}
             required={required}
             selectThreshold={this.selectThreshold}
             withNull={withNull}
@@ -94,6 +123,7 @@ const mapStateToProps = (state) => ({
   fetchingInsureeOfficers: state.insuree.fetchingInsureeOfficers,
   fetchedInsureeOfficers: state.insuree.fetchedInsureeOfficers,
   errorInsureeOfficers: state.insuree.errorInsureeOfficers,
+  user: state.core.user
 });
 
 const mapDispatchToProps = (dispatch) => {

--- a/src/pickers/InsureeOfficerPicker.js
+++ b/src/pickers/InsureeOfficerPicker.js
@@ -28,8 +28,9 @@ class InsureeOfficer extends Component {
   componentDidMount() {
    if (!this.props.fetchedInsureeOfficers || !this.isCurrentAdminEnrollmentOfficerActive == false) {
       const filters = [];
-      !!this.props.locationId && this.props.locationId != "" ? filters.push(`locationId:"${decodeId(this.props.locationId)}"`) : filters;
-
+      if(!!this.props.locationId && this.props.locationId != ""){
+        filters.push(`locationId:"${decodeId(this.props.locationId)}"`)
+      }
       // prevent loading multiple times the cache when component is
       // several times on tha page
 


### PR DESCRIPTION
When adding a photo for an insuree, the system currently requires selecting an enrolment officer from a list of all officers in the database. This step is time-consuming and unnecessary in some implementations where the officer adding the photo is always the one logged in.

To optimize the workflow, we propose two alternative behaviors, to be controlled via a configuration setting:

📌 Change to do :

Remove Selection from UI, Set in Backend

The frontend does not manage enrolment officer selection.

If the current user connected is not an enrolment officier it’s not possible to save the insuree (even if the user is an admin)

The backend auto-fills the officer field based on the current session.

Easier to manage on frontend, but requires context-aware backend updates.

Several rules that should be considered:

If the user is not an EO but it still has the possibility to create/edit an insuree, the filtered list of EOs that are attached to the Family’s village should be available to select one EO.

If the user is not an EO but it still has the possibility to create/edit an insuree, and there is no EO attached to the Village, full list of EOs should be available to select one EO.

If the user is an EO, the selection is by default the user in readonly mode