### PR TITLE
Feat: Prefill the officer photo value field when the insuree form is in creation mode and the EO is logged in

### DIFF
--- a/src/components/InsureeAvatar.js
+++ b/src/components/InsureeAvatar.js
@@ -40,9 +40,7 @@ const InsureeAvatar = (props) => {
           // is enrollment officer ??
           const isOfficer = data.i_user !== null && data.i_user !== undefined;
           setIsEnrollmentOfficer(isOfficer);
-          
-          console.log("Is Enrollment Officer:", isOfficer);
-          
+                    
           setCurrentUser({
             username: username,
             userId: data.i_user?.id || data.t_user?.id,

--- a/src/components/InsureeAvatar.js
+++ b/src/components/InsureeAvatar.js
@@ -1,9 +1,11 @@
 import React from "react";
 import { withTheme, withStyles } from "@material-ui/core/styles";
-import { Avatar, Grid, IconButton } from "@material-ui/core";
+import { Avatar, Grid, IconButton, Typography, TextField } from "@material-ui/core";
 import { toISODate, useModulesManager, useTranslations, PublishedComponent } from "@openimis/fe-core";
 import _ from "lodash";
 import moment from "moment";
+import { loadCurrentUser } from "../utils/utils";
+import { useDispatch } from "react-redux";
 
 const styles = (theme) => ({
   bigAvatar: theme.bigAvatar,
@@ -17,9 +19,45 @@ const styles = (theme) => ({
 });
 
 const InsureeAvatar = (props) => {
-  const { photo, classes, className, withMeta = false, readOnly, onChange , required} = props;
+  const { photo, classes, className, withMeta = false, readOnly, onChange, required } = props;
   const modulesManager = useModulesManager();
   const { formatMessage } = useTranslations("insuree", modulesManager);
+  const dispatch = useDispatch();
+  
+  const [currentUser, setCurrentUser] = React.useState(null);
+  const [isEnrollmentOfficer, setIsEnrollmentOfficer] = React.useState(false);
+  const isCreateMode = !photo || (!photo.photo && !photo.filename);
+  
+  React.useEffect(() => {
+    if (isCreateMode && !readOnly) {
+      
+      loadCurrentUser(dispatch).then((response) => {
+        if (response && response.payload) {
+          const data = response.payload;
+          const username = data.username;
+          const userType = data.i_user ? 'i_user' : data.t_user ? 't_user' : 'unknown';
+          
+          // is enrollment officer ??
+          const isOfficer = data.i_user !== null && data.i_user !== undefined;
+          setIsEnrollmentOfficer(isOfficer);
+          
+          console.log("Is Enrollment Officer:", isOfficer);
+          
+          setCurrentUser({
+            username: username,
+            userId: data.i_user?.id || data.t_user?.id,
+            fullData: data
+          });
+          
+          if (isOfficer && data.i_user?.id) {
+            onChange({ ...photo, officerId: data.i_user.id });
+          }
+        }
+      }).catch(error => {
+        console.error(error);
+      });
+    }
+  }, [isCreateMode, readOnly, dispatch]);
 
   const getUrl = (photo) => {
     if (photo?.photo) {
@@ -83,15 +121,26 @@ const InsureeAvatar = (props) => {
             />
           </Grid>
           <Grid item className={classes.item}>
-            <PublishedComponent
-              pubRef="insuree.InsureeOfficerPicker"
-              value={photo?.officerId}
-              module="insuree"
-              label={formatMessage("Insuree.photoOfficer")}
-              readOnly={readOnly}
-              required={isRequired}
-              onChange={(v) => onChange({ ...photo, officerId: v?.id })}
-            />
+            {isCreateMode && !readOnly && isEnrollmentOfficer ? (
+              <TextField
+                fullWidth
+                disabled
+                label={formatMessage("Insuree.photoOfficer")}
+                value={currentUser?.username || "Loading..."}
+                variant="outlined"
+                size="small"
+              />
+            ) : (
+              <PublishedComponent
+                pubRef="insuree.InsureeOfficerPicker"
+                value={photo?.officerId}
+                module="insuree"
+                label={formatMessage("Insuree.photoOfficer")}
+                readOnly={readOnly}
+                required={isRequired}
+                onChange={(v) => onChange({ ...photo, officerId: v?.id })}
+              />
+            )}
           </Grid>
         </Grid>
       )}

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -1,5 +1,8 @@
 import _ from "lodash";
 import { INSUREE_ACTIVE_STRING } from "../constants";
+import { RSAA } from "redux-api-middleware";
+import { baseApiUrl } from "@openimis/fe-core";
+const REQUESTED_WITH = 'XMLHttpRequest';
 
 export function insureeLabel(insuree) {
   if (!insuree) return "";
@@ -54,3 +57,19 @@ export const formatLocationString = (family) => {
     .filter(Boolean)
     .join(", ");
 };
+
+export function loadCurrentUser(dispatch) {
+  const csrfToken = localStorage.getItem('csrfToken');
+  return dispatch({
+    [RSAA]: {
+      endpoint: `${baseApiUrl}/core/users/current_user/`,
+      method: "GET",
+      types: ["CORE_USERS_CURRENT_USER_REQ", "CORE_USERS_CURRENT_USER_RESP", "CORE_USERS_CURRENT_USER_ERR"],
+      headers: {
+        "Content-Type": "application/json",
+        'X-Requested-With': REQUESTED_WITH,
+        "X-CSRFToken": csrfToken,
+      },
+    },
+  });
+}


### PR DESCRIPTION
# Description

> this PR is a reproduction of an existing PR that implements the same feature but it is required for the next release:
https://github.com/openimis/openimis-fe-insuree_js/pull/162


## Changes

- [X] recreate the current user fetching in the Insuree module repository.
- [X] set a condition for the Insuree form so that when it is in creation mode, the “Officer Photo” field is prefilled with the username of the logged in user

## Demo

https://github.com/user-attachments/assets/d324145e-2aee-472e-973c-1fcf4ec94371

## How to Test

* open the Insuree page

* press the (+) button to create a new insuree

* you will notice that the Officer Photo field is prefilled with the logged in enrollment officer's ID