### PR TITLE
fix: remove insuree from family

### DIFF
--- a/src/components/FamilyInsureesOverview.js
+++ b/src/components/FamilyInsureesOverview.js
@@ -272,7 +272,7 @@ class FamilyInsureesOverview extends PagedDataHandler {
 
   removeInsureeAction = (removeInsuree) => (
     <Tooltip title={formatMessage(this.props.intl, "insuree", "familyRemoveInsuree.tooltip")}>
-      <Button onClick={(e) => this.removeInsuree(removeInsuree)} startIcon={<RemoveIcon />}>
+      <Button onClick={() => this.setState({ removeInsuree })} startIcon={<RemoveIcon />}>
         {formatMessage(this.props.intl, "insuree", "familyRemoveInsuree.buttonText")}
       </Button>
     </Tooltip>


### PR DESCRIPTION
# Description

This PR fixes the functionality for removing a family member. Previously, attempting to remove a family member caused a JavaScript error (null pointer exception) to crash the application.

This PR should also be integrated into vite-migrations.

# Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo

<img width="1852" height="989" alt="image" src="https://github.com/user-attachments/assets/849c3141-8d2c-429e-ac48-905b95ce655c" />
<img width="1852" height="989" alt="image" src="https://github.com/user-attachments/assets/f2ea2f5e-2c59-4cf0-b154-9e3fd36619a6" />

## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
