### PR TITLE
Fix typo in FamilySearcher constructor causing rendering failure in InsureeModule

### DIFF
--- a/src/components/FamilySearcher.jsx
+++ b/src/components/FamilySearcher.jsx
@@ -43,7 +43,7 @@ class FamilySearcher extends Component {
     );
     this.columns = this.props.modulesManager.getConf("fe-insuree", "searcherColumnsConfig", {});
     this.defaultPageSize = this.props.modulesManager.getConf("fe-insuree", "familyFilter.defaultPageSize", 10);
-    this.locationLevels = this.this.props.modulesManager.getConf("fe-location", "location.Location.MaxLevels", 4);
+    this.locationLevels = this.props.modulesManager.getConf("fe-location", "location.Location.MaxLevels", 4);
     this.renderLastNameFirst = this.props.modulesManager.getConf(
       "fe-insuree",
       "renderLastNameFirst",


### PR DESCRIPTION
…nsureeModule

#Thank you for your contribution to openIMIS!
#Please complete the sections below. Anything in comments is guidance and can be deleted.

# Description

A clear, concise description of the change. Why is it needed? What problem does it solve?

# Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo

Issue was with 
<img width="518" height="149" alt="image" src="https://github.com/user-attachments/assets/930fbc00-2372-41dc-801b-be987d0c5f56" />
The render class crashed with white screen.

After fix,

<img width="1065" height="798" alt="image" src="https://github.com/user-attachments/assets/3cf8e387-df38-4d4f-8994-7d8a2965f382" />


## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
