### PR TITLE
add space between insuree number & name

### DIFF
--- a/src/pickers/InsureeChfIdPicker.jsx
+++ b/src/pickers/InsureeChfIdPicker.jsx
@@ -3,7 +3,7 @@ import { connect } from "react-redux";
 import { injectIntl } from "react-intl";
 import { bindActionCreators } from "redux";
 import { Grid } from "@mui/material";
-import { withModulesManager, TextInput, ProgressOrError, formatMessage } from "@openimis/fe-core";
+import { withModulesManager, TextInput, ProgressOrError, formatMessage, GRID_RESPONSIVE_HALF } from "@openimis/fe-core";
 
 import { fetchInsuree } from "../actions";
 import isEqual from "lodash/isEqual";
@@ -82,8 +82,8 @@ class InsureeChfIdPicker extends Component {
   render() {
     const { readOnly = false, required = false } = this.props;
     return (
-      <Grid container>
-        <Grid size={4}>
+      <Grid container spacing={2}>
+        <Grid size={GRID_RESPONSIVE_HALF}>
           <TextInput
             readOnly={readOnly}
             autoFocus={true}
@@ -97,7 +97,7 @@ class InsureeChfIdPicker extends Component {
             required={required}
           />
         </Grid>
-        <Grid size={8}>
+        <Grid size={GRID_RESPONSIVE_HALF}>
           <ProgressOrError progress={this.props.fetching} error={this.props.error} />
           {!this.props.fetching && (
             <TextInput


### PR DESCRIPTION
# Description

In the claim form, the Insured Number field is too close to the Insured Name field; I added spacing and adjusted the size of component

# Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo

<img width="1200" height="443" alt="Screenshot 2026-07-07 at 4 41 31 PM" src="https://github.com/user-attachments/assets/0156be4f-8838-4545-9f2d-ee2ddd6184ab" />
<img width="1430" height="744" alt="Screenshot 2026-07-08 at 4 14 08 PM" src="https://github.com/user-attachments/assets/ab7fc537-0d03-42b2-8503-5b941bc6532f" />


## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
