### PR TITLE
fix length of location field

### DIFF
--- a/src/components/FamilyMasterPanel.jsx
+++ b/src/components/FamilyMasterPanel.jsx
@@ -22,7 +22,7 @@ import {
 } from "@openimis/fe-core";
 
 const GRID_FAMILY_ADDRESS = { xs: 12, sm: 12, md: 8, lg: 5 };
-const GRID_FAMILY_POVERTY = { xs: 12, sm: 6, md: 4, lg: 1 };
+const GRID_FAMILY_POVERTY = { xs: 12, sm: 6, md: 4, lg: 5 };
 import { DEFAULT } from "../constants";
 const PeopleIcon = GetIconComponent("People")
 
@@ -158,7 +158,7 @@ class FamilyMasterPanel extends FormPanel {
           </Grid>
           <Divider />
           <Grid container className="item">
-            <Grid size={GRID_RESPONSIVE_FULL} className="item">
+            <Grid size={GRID_RESPONSIVE_STANDARD} className="item">
               <PublishedComponent
                 pubRef="location.LocationCascader"
                 module="location"


### PR DESCRIPTION
#Thank you for your contribution to openIMIS!
#Please complete the sections below. Anything in comments is guidance and can be deleted.

# Description

In the insuree form, the Location field spans the entire width of the page, which results in a poor UI layout

# Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo

<img width="1349" height="549" alt="Screenshot 2026-07-09 at 4 39 58 PM" src="https://github.com/user-attachments/assets/85ccfc2c-4373-4954-abda-6641b2217923" />


## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
