### PR TITLE
fix location field size in filter

### DIFF
--- a/src/components/FamilyFilter.jsx
+++ b/src/components/FamilyFilter.jsx
@@ -331,7 +331,7 @@ class FamilyFilter extends Component {
             module="insuree"
             id="FamilyFilter.location"
             field={
-              <Grid size={GRID_RESPONSIVE_FULL}>
+              <Grid size={GRID_RESPONSIVE_STANDARD}>
                 <PublishedComponent
                   pubRef="location.LocationCascader"
                   module="location"

--- a/src/components/InsureeFilter.jsx
+++ b/src/components/InsureeFilter.jsx
@@ -135,7 +135,7 @@ class InsureeFilter extends Component {
             module="insuree"
             id="InsureeFilter.location"
             field={
-              <Grid size={GRID_RESPONSIVE_FULL}>
+              <Grid size={GRID_RESPONSIVE_STANDARD}>
                 <PublishedComponent
                   pubRef="location.LocationCascader"
                   module="location"


### PR DESCRIPTION
# Description

The Location field was unusually wide in the Insured and Family filter panels. I reduced its width to GRID_RESPONSIVE_STANDARD

# Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo

<img width="1391" height="466" alt="Screenshot 2026-07-14 at 1 21 33 PM" src="https://github.com/user-attachments/assets/c477f657-4b2c-4b4f-acc9-f0b6a8e7ce2f" />


## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
