### PR TITLE
fix(insuree): display backend validation message for insuree number

### DIFF
--- a/src/components/InsureeMasterPanel.jsx
+++ b/src/components/InsureeMasterPanel.jsx
@@ -12,7 +12,8 @@ import {
   withModulesManager,
   GRID_RESPONSIVE_FULL,
   GRID_RESPONSIVE_SMALL,
-  GRID_RESPONSIVE_STANDARD
+  GRID_RESPONSIVE_STANDARD,
+  GRID_RESPONSIVE_LARGE
 } from "@openimis/fe-core";
 import { DEFAULT, INSUREE_ACTIVE_STRING } from "../constants";
 

--- a/src/pickers/InsureeNumberInput.jsx
+++ b/src/pickers/InsureeNumberInput.jsx
@@ -38,6 +38,7 @@ const InsureeNumberInput = (props) => {
       isValid={isInsureeNumberValid}
       isValidating={isInsureeNumberValidating}
       validationError={insureeNumberValidationError}
+      showValidationErrorAsHelperText
       action={insureeNumberValidationCheck}
       clearAction={insureeNumberValidationClear}
       setValidAction={insureeNumberSetValid}


### PR DESCRIPTION
#Thank you for your contribution to openIMIS!
#Please complete the sections below. Anything in comments is guidance and can be deleted.

# Description

Display backend validation error messages directly in the UI for the insuree number field, providing users with clear feedback when an invalid number is entered.

# Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [x] Requires https://github.com/openimis/openimis-be-insuree_py/pull/171,  https://github.com/openimis/openimis-fe-core_js/pull/346
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo

<img width="901" height="500" alt="image" src="https://github.com/user-attachments/assets/56b28d63-fe78-4800-8e28-911efa6c95f2" />

## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
